### PR TITLE
Add cue for assistive technology users to indicate that they landed on a new page -- LIBWEB-495.

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -61,10 +61,4 @@ export const onRouteUpdate = ({ location, prevLocation }) => {
       h1.focus()
     }
   }
-
-  /*
-    Potential plan:
-    1. Find h1
-    2. If found, add index -1 and set focus to h1.
-  */
 }

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -58,6 +58,7 @@ export const onRouteUpdate = ({ location, prevLocation }) => {
 
     if (h1) {
       h1.setAttribute('tabindex', '-1')
+      h1.classList.add('focus')
       h1.focus()
     }
   }

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -35,14 +35,36 @@ export const wrapPageElement = ({ element, props }) => {
     <React.Fragment>
       {element}
       <LargeScreen>
-        <span id="ask-a-librarian-chat" css={{
-          'button': {
-            outlineColor: COLORS.maize['400']
-          }
-        }}>
+        <span
+          id="ask-a-librarian-chat"
+          css={{
+            button: {
+              outlineColor: COLORS.maize['400'],
+            },
+          }}
+        >
           <Chat fixed />
         </span>
       </LargeScreen>
     </React.Fragment>
   )
+}
+
+export const onRouteUpdate = ({ location, prevLocation }) => {
+  const oldPath = prevLocation ? prevLocation.pathname : null
+
+  if (oldPath) {
+    const h1 = document.querySelector('h1')
+
+    if (h1) {
+      h1.setAttribute('tabindex', '-1')
+      h1.focus()
+    }
+  }
+
+  /*
+    Potential plan:
+    1. Find h1
+    2. If found, add index -1 and set focus to h1.
+  */
 }

--- a/src/components/aside-layout.js
+++ b/src/components/aside-layout.js
@@ -31,7 +31,7 @@ export function Template({ children, asideWidth, ...rest }) {
 
 export function TemplateSide({ children, ...rest }) {
   return (
-    <aside
+    <region
       css={{
         [MEDIA_QUERIES['L']]: {
           gridArea: 'side',
@@ -54,7 +54,7 @@ export function TemplateSide({ children, ...rest }) {
       >
         {children}
       </div>
-    </aside>
+    </region>
   )
 }
 

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,11 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Global } from '@emotion/core'
-import {
-  UniversalHeader,
-  GlobalStyleSheet,
-  COLORS,
-} from '@umich-lib/core'
+import { UniversalHeader, GlobalStyleSheet, COLORS } from '@umich-lib/core'
 import Header from './header'
 import Footer from './footer'
 import DevelopmentAlert from './development-alert'
@@ -25,6 +21,19 @@ function Layout({ children, drupalNid }) {
           },
           '*:focus': {
             outlineColor: COLORS.blue['400'],
+          },
+          'h1.focus': {
+            position: 'relative',
+            '&:focus': {
+              outline: '0',
+              '&:before': {
+                content: '""',
+                position: 'absolute',
+                height: '100%',
+                left: '-0.3em',
+                borderLeft: `solid 4px ${COLORS.teal['400']}`,
+              },
+            },
           },
         }}
       />

--- a/src/components/page-layout.js
+++ b/src/components/page-layout.js
@@ -34,7 +34,7 @@ export function Top({ children, ...rest }) {
 
 export function Side({ children, ...rest }) {
   return (
-    <aside
+    <region
       css={{
         [MEDIA_QUERIES.LARGESCREEN]: {
           gridArea: 'side',
@@ -44,7 +44,7 @@ export function Side({ children, ...rest }) {
       {...rest}
     >
       {children}
-    </aside>
+    </region>
   )
 }
 

--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -4,16 +4,17 @@ import { graphql } from 'gatsby'
 import Layout from '../components/layout'
 import SEO from '../components/seo'
 import Panels from '../components/panels'
+import VisuallyHidden from '@reach/visually-hidden'
 
 function BasicTemplate({ data, ...rest }) {
-  const {
-    drupal_internal__nid,
-    relationships,
-  } = data.page
+  const { drupal_internal__nid, relationships, title } = data.page
 
   return (
     <Layout drupalNid={drupal_internal__nid}>
       <SEO />
+      <VisuallyHidden>
+        <h1>Home page</h1>
+      </VisuallyHidden>
       <Panels data={relationships.field_panels} />
     </Layout>
   )


### PR DESCRIPTION
## What
Use Gatsby's browser API `onRouteUpdate` to catch when a user routes to a new page and then set focus on the first `h1`, so that its read to screen reader users and the new destination is understood.

## Why
With JavaScript client-side routing, users of assistive technology might not know that they routed to a new page, so single page application sites need to add this feedback cue.

There are a few options for adding back in page routing cues for client-side routing which Marcy Sutton describes well and provides prototypes of each (https://marcy.codes/prototypes/routing/index.html). Based on her post of testing and research it seems focusing on the first heading (h1) of the page was the best experience and option for the various prototypes (https://www.gatsbyjs.org/blog/2019-07-11-user-testing-accessible-client-routing/).

## Demo

Using Safari and VoiceOver to navigate to a new page via site search. Notice the destination `h1` receives focus after routing.

Development preview: https://dev.lib.umich.edu/

![](http://g.recordit.co/pzzQRFiCM3.gif)
