### PR TITLE
Add formatting option for an hours aria label.

### DIFF
--- a/src/components/hours-table.js
+++ b/src/components/hours-table.js
@@ -54,11 +54,12 @@ function HoursTable({ data, headingId, dayOfWeek = false }) {
         <thead>
           <tr>
             <th colSpan="2" />
-            {data.headings.map(({ text, subtext }, i) => (
+            {data.headings.map(({ text, subtext, label }, i) => (
               <th
                 scope="col"
                 aria-current={i === todayIndex}
                 key={text + subtext + i}
+                aria-label={label}
               >
                 <div
                   css={{
@@ -103,13 +104,13 @@ function HoursTable({ data, headingId, dayOfWeek = false }) {
           {data.rows.map((row, y) => (
             <tr key={row + y}>
               {row.map((col, i) => (
-                <React.Fragment key={row + col + y + i}>
+                <React.Fragment key={row + col.label + y + i}>
                   {i === 0 ? (
-                    <th scope="row" colSpan="2">
-                      {col}
+                    <th scope="row" colSpan="2" aria-label={col.label}>
+                      {col.text}
                     </th>
                   ) : (
-                    <td>{col}</td>
+                    <td aria-label={col.label}>{col.text}</td>
                   )}
                 </React.Fragment>
               ))}

--- a/src/components/panels/hours-lite-panel.js
+++ b/src/components/panels/hours-lite-panel.js
@@ -1,11 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import {
-  SPACING,
-  Icon,
-  TYPOGRAPHY,
-  COLORS,
-  Heading,
-} from '@umich-lib/core'
+import { SPACING, Icon, TYPOGRAPHY, COLORS, Heading } from '@umich-lib/core'
 import * as moment from 'moment'
 import { Link as GatsbyLink } from 'gatsby'
 
@@ -16,9 +10,7 @@ import { displayHours } from '../../utils/hours'
 
 export default function HoursLitePanel({ data }) {
   const [initialized, setInitialized] = useState(false)
-  const {
-    field_title
-  } = data
+  const { field_title } = data
   const hours = processHoursData(data.relationships.field_cards, initialized)
 
   useEffect(() => {
@@ -27,61 +19,85 @@ export default function HoursLitePanel({ data }) {
 
   return (
     <section>
-      <Heading level={2} size="XL">{field_title}</Heading>
+      <Heading level={2} size="XL">
+        {field_title}
+      </Heading>
 
-      <ol css={{
-        marginTop: SPACING['L']
-      }}>
+      <ol
+        css={{
+          marginTop: SPACING['L'],
+        }}
+      >
         {hours.map((h, i) => (
-          <li key={i + h.text + h.to} css={{
-            display: 'flex'
-          }}>
-            <span css={{
-              display: 'inline',
-              color: COLORS.maize['500'],
-              width: '1.5rem',
-              flexShrink: '0'
-            }}>
+          <li
+            key={i + h.text + h.to}
+            css={{
+              display: 'flex',
+            }}
+          >
+            <span
+              css={{
+                display: 'inline',
+                color: COLORS.maize['500'],
+                width: '1.5rem',
+                flexShrink: '0',
+              }}
+            >
               <Icon d={icons['clock']} />
             </span>
-            <GatsbyLink to={h.to} css={{
-              flex: '1',
-              ':hover span': {
-                textDecoration: 'underline'
-              },
-              paddingBottom: `${SPACING['S']}`
-            }}>
+            <GatsbyLink
+              to={h.to}
+              css={{
+                flex: '1',
+                ':hover span': {
+                  textDecoration: 'underline',
+                },
+                paddingBottom: `${SPACING['S']}`,
+              }}
+            >
               <span>
                 <span
                   data-text
                   css={{
-                  display: 'block',
-                  [MEDIA_QUERIES['M']]: {
+                    display: 'block',
+                    [MEDIA_QUERIES['M']]: {
+                      display: 'inline-block',
+                      marginRight: SPACING['XS'],
+                    },
+                  }}
+                >
+                  {h.text}
+                </span>
+                <span
+                  css={{
                     display: 'inline-block',
-                    marginRight: SPACING['XS']
-                  }
-                }}>{h.text}</span>
-                <span css={{
-                  display: 'inline-block',
-                  marginTop: SPACING['3XS'],
-                  [MEDIA_QUERIES['M']]: {
-                    marginTop: '0',
-                    display: 'inline-block'
-                  },
-                  ...TYPOGRAPHY['3XS'],
-                  color: COLORS.neutral['300'],
-                  textTransform: 'uppercase',
-                  fontWeight: '700',
-                  fontSize: '0.875rem',
-                }}>{h.subText}</span>
+                    marginTop: SPACING['3XS'],
+                    [MEDIA_QUERIES['M']]: {
+                      marginTop: '0',
+                      display: 'inline-block',
+                    },
+                    ...TYPOGRAPHY['3XS'],
+                    color: COLORS.neutral['300'],
+                    textTransform: 'uppercase',
+                    fontWeight: '700',
+                    fontSize: '0.875rem',
+                  }}
+                  aria-label={h.subLabel}
+                >
+                  {h.subText}
+                </span>
               </span>
             </GatsbyLink>
-            </li>
-          ))}
+          </li>
+        ))}
         <li>
-          <Link kind="list-strong" to="/locations-and-hours" css={{
-            marginLeft: '1.5rem'
-          }}>
+          <Link
+            kind="list-strong"
+            to="/locations-and-hours"
+            css={{
+              marginLeft: '1.5rem',
+            }}
+          >
             View all hours and locations
           </Link>
         </li>
@@ -119,17 +135,20 @@ function processHoursData(data, initialized) {
   function hours(node) {
     if (initialized) {
       const now = moment()
-      return displayHours({node, now})
+      return displayHours({ node, now })
     }
 
-    return '...'
+    return { text: '...', label: 'Loading hours... ' }
   }
 
   const result = data.map(node => {
+    const { text, label } = hours(node)
+
     return {
       text: node.title,
-      subText: 'TODAY: ' + hours(node),
-      to: node.fields.slug
+      subText: 'TODAY: ' + text,
+      subLabel: 'TODAY: ' + label,
+      to: node.fields.slug,
     }
   })
 

--- a/src/components/panels/hours-panel.js
+++ b/src/components/panels/hours-panel.js
@@ -25,6 +25,13 @@ export function HoursPanelNextPrev() {
     .add(weekOffset, 'weeks')
     .endOf('week')
 
+  const hoursRange = {
+    text: `${from_date.format('MMM D')} - ${to_date.format('MMM D')}`,
+    label: `Showing hours from ${from_date.format(
+      'dddd, MMMM Do YYYY'
+    )} to ${to_date.format('dddd, MMMM Do, YYYY')}`,
+  }
+
   return (
     <Margins data-hours-panel-next-previous>
       <div
@@ -48,9 +55,12 @@ export function HoursPanelNextPrev() {
           Previous week
         </PreviousNextWeekButton>
         <Heading level={2} size="S" css={{ fontWeight: '700' }}>
-          <span aria-live="polite" aria-atomic="true">
-            <VisuallyHidden>Showing hours for </VisuallyHidden>
-            {from_date.format('MMM D')} - {to_date.format('MMM D')}
+          <span
+            aria-live="polite"
+            aria-atomic="true"
+            aria-label={hoursRange.label}
+          >
+            {hoursRange.text}
           </span>
         </Heading>
         <PreviousNextWeekButton
@@ -208,12 +218,14 @@ function transformTableData({ node, now }) {
     [
       {
         text: 'Sun',
-        subtext: 'Apr 15'
+        subtext: 'Apr 15',
+        label: 'Sunday, April 15th'
       },
       ...
       {
         text: 'Sat',
-        subtext: 'Apr 21'
+        subtext: 'Apr 21',
+        label: 'Saturday, April 21th'
       },
     ]
   */
@@ -223,6 +235,7 @@ function transformTableData({ node, now }) {
     headings = headings.concat({
       text: now.day(i).format('ddd'),
       subtext: now.day(i).format('MMM D'),
+      label: now.day(i).format('dddd, MMMM Do'),
     })
   }
 
@@ -233,8 +246,8 @@ function transformTableData({ node, now }) {
 
     [
       [
-        'General',
-        '24 hours',
+        { text: 'General', label: 'General' },
+        { text: '24 hours', label: '24 hours' },
         ...
       ]
     ]
@@ -277,6 +290,9 @@ function transformTableData({ node, now }) {
 */
 function getRow(node, nowWithWeekOffset, isParent) {
   let hours = []
+  const notAvailableRow = { text: 'n/a', label: 'Not available' }
+  const rowHeadingText = [isParent ? 'Main hours' : node.title]
+  const mainHoursRow = { text: rowHeadingText, label: rowHeadingText }
 
   for (let i = 0; i < 7; i++) {
     const now = moment(nowWithWeekOffset).day(i)
@@ -285,8 +301,8 @@ function getRow(node, nowWithWeekOffset, isParent) {
       now,
     })
 
-    hours = hours.concat(display ? display : 'n/a')
+    hours = hours.concat(display ? display : notAvailableRow)
   }
 
-  return [isParent ? 'Main hours' : node.title].concat(hours)
+  return [mainHoursRow].concat(hours)
 }

--- a/src/components/todays-hours.js
+++ b/src/components/todays-hours.js
@@ -25,5 +25,5 @@ export default function Hours({ node }) {
     return 'n/a'
   }
 
-  return <React.Fragment>{hours}</React.Fragment>
+  return <span aria-label={hours.label}>{hours.text}</span>
 }

--- a/src/utils/hours.js
+++ b/src/utils/hours.js
@@ -74,7 +74,7 @@ export function displayHours({ node, now }) {
 
   const text =
     moment(start, 'HHmm').format('h a') +
-    '–' +
+    ' - ' +
     moment(end, 'HHmm').format('h a')
   const label =
     moment(start, 'HHmm').format('h a') +
@@ -85,12 +85,6 @@ export function displayHours({ node, now }) {
     text,
     label,
   }
-
-  return (
-    moment(start, 'HHmm').format('h a') +
-    '–' +
-    moment(end, 'HHmm').format('h a')
-  )
 }
 
 /*

--- a/src/utils/hours.js
+++ b/src/utils/hours.js
@@ -58,7 +58,10 @@ export function displayHours({ node, now }) {
   const { starthours, endhours, comment } = hoursForNow
 
   if (comment) {
-    return comment
+    return {
+      text: comment,
+      label: comment,
+    }
   }
 
   // Needs to be 24 time format, ie ####.
@@ -69,10 +72,24 @@ export function displayHours({ node, now }) {
     return null
   }
 
+  const text =
+    moment(start, 'HHmm').format('h a') +
+    '–' +
+    moment(end, 'HHmm').format('h a')
+  const label =
+    moment(start, 'HHmm').format('h a') +
+    ' to ' +
+    moment(end, 'HHmm').format('h a')
+
+  return {
+    text,
+    label,
+  }
+
   return (
-    moment(start, 'HHmm').format('ha') +
-    ' - ' +
-    moment(end, 'HHmm').format('ha')
+    moment(start, 'HHmm').format('h a') +
+    '–' +
+    moment(end, 'HHmm').format('h a')
   )
 }
 


### PR DESCRIPTION
## What

With this change we can control how hours are displayed visually and also how they should be understood to assistive technologies via an `aria label`.

Hours are formatted with [Moment.js.](https://momentjs.com/)

## Why

So that we provide a good experience of abbreviated hours information to users that use assistive technologies.

## Example

From the "Location and Hours: Hours View" page.

```html
// Hours range summary text
<span aria-live="polite" aria-atomic="true" aria-label="Showing hours from Sunday, January 12th 2020 to Saturday, January 18th, 2020">Jan 12 - Jan 18</span>

...

// Hours table cell
<td aria-label="10 am to 6 pm">10 am - 6 pm</td>
```