### PR TITLE
add netlify.toml for wildcard redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+ from = "/database/*"
+ to = "https://apps.lib.umich.edu/database/:splat"
+ status = 200
+ force = true


### PR DESCRIPTION
need to try this. _redirects doesnt support wildcards (https://community.netlify.com/t/how-do-i-apply-a-redirect-to-a-wildcard-file-name/1397) and so this will get processed after _redirects (https://www.netlify.com/blog/2019/01/16/redirect-rules-for-all-how-to-configure-redirects-for-your-static-site/)