### PR TITLE
Bugfix for the header SSR display none issue.

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,30 +1,17 @@
 import React from 'react'
+import WindowSize, { useWindowSize } from '@reach/window-size'
+
 import HeaderLargeScreen from './header-largescreen'
 import HeaderSmallScreen from './header-smallscreen'
 
 function Header({ primary, secondary }) {
-  return (
-    <React.Fragment>
-      <div
-        css={{
-          [`@media only screen and (max-width: 1129px)`]: {
-            display: 'none',
-          },
-        }}
-      >
-        <HeaderLargeScreen primary={primary} secondary={secondary} />
-      </div>
-      <div
-        css={{
-          [`@media only screen and (min-width: 1130px)`]: {
-            display: 'none',
-          },
-        }}
-      >
-        <HeaderSmallScreen primary={primary} secondary={secondary} />
-      </div>
-    </React.Fragment>
-  )
+  const { width } = useWindowSize()
+
+  if (width > 1129) {
+    return <HeaderLargeScreen primary={primary} secondary={secondary} />
+  }
+
+  return <HeaderSmallScreen primary={primary} secondary={secondary} />
 }
 
 export default Header


### PR DESCRIPTION
Somehow on rehydration the display non div for the small/large header wrapped the entire page. Replacing that markup with reach ui window size hook. Seems to fix that issue.