### PR TITLE
Improve accessibility of site search -- LIBWEB-659

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gatsby-plugin-sitemap": "^2.4.10",
     "gatsby-source-drupal": "^3.3.10",
     "gatsby-transformer-sharp": "^2.4.6",
+    "highlight-words-core": "^1.2.2",
     "moment": "^2.24.0",
     "patch-package": "^6.2.0",
     "prettier": "^1.19.1",

--- a/src/components/site-search-modal.js
+++ b/src/components/site-search-modal.js
@@ -5,28 +5,35 @@ import { SPACING, Z_SPACE } from '@umich-lib/core'
 import SiteSearch from './site-search'
 import MEDIA_QUERIES from '../maybe-design-system/media-queries'
 
+import '@reach/dialog/styles.css'
+
 function SiteSearchModal({ handleDismiss }) {
   return (
     <React.Fragment>
       <Dialog
         onDismiss={handleDismiss}
         css={{
-          width: `calc(100% - ${SPACING['M']} * 2)`,
-          margin: SPACING['M'],
-          padding: '0',
-          ...Z_SPACE['16'],
-          borderRadius: '2px',
-          '[data-site-search-icon]': {
-            left: SPACING['L'],
-          },
-          '[data-reach-combobox-input]': {
-            padding: `${SPACING['M']} ${SPACING['L']}`,
-            paddingLeft: `calc(${SPACING['XL']} + ${SPACING['L']})`,
-            border: 'none',
-          },
-          [MEDIA_QUERIES['M']]: {
-            width: '82vw',
-            margin: '7vh auto',
+          '&[data-reach-dialog-content]': {
+            width: `calc(100% - ${SPACING['M']} * 2)`,
+            margin: SPACING['M'],
+            padding: '0',
+            ...Z_SPACE['16'],
+            borderRadius: '2px',
+            '[data-site-search-icon]': {
+              left: SPACING['L'],
+            },
+            input: {
+              padding: `${SPACING['S']} ${SPACING['L']}`,
+              paddingLeft: `calc(${SPACING['XL']} + ${SPACING['L']})`,
+              border: 'none',
+            },
+            [MEDIA_QUERIES['M']]: {
+              width: '82vw',
+              margin: `${SPACING['L']} auto`,
+            },
+            '[data-site-search-keyboard-instructions]': {
+              display: 'none',
+            },
           },
         }}
       >

--- a/src/components/site-search.js
+++ b/src/components/site-search.js
@@ -208,7 +208,7 @@ function ResultsList({ searching, noResults, results, query, error }) {
         <KeyboardControlIntructions />
       </p>
       <ol>
-        {results.slice(0, 10).map((result, index) => (
+        {results.slice(0, 100).map((result, index) => (
           <li
             key={index}
             value={result.title}

--- a/src/components/site-search.js
+++ b/src/components/site-search.js
@@ -178,6 +178,8 @@ function ResultsContainer({ results, query, error, openResults }) {
   const searching = query.length > 0
   const noResults = searching && results.length === 0
 
+  // Do not render results, if user just hit ESC.
+  // This is reset when the query changes.
   if (!openResults) {
     return null
   }

--- a/src/components/site-search.js
+++ b/src/components/site-search.js
@@ -272,38 +272,11 @@ function ResultsList({ searching, noResults, results, query, error }) {
                 },
               }}
             >
-              <p
-                data-title
-                css={{
-                  ...TYPOGRAPHY['XS'],
-                  mark: {
-                    background: COLORS.maize['200'] + '!important',
-                    fontWeight: '700',
-                  },
-                }}
-                aria-label={result.title + '.'}
-              >
-                <HighlightText query={query} text={result.title} />
-              </p>
-              {result.summary && (
-                <p
-                  css={{
-                    display: '-webkit-box',
-                    color: COLORS.neutral['300'],
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    '-webkit-line-clamp': '2',
-                    '-webkit-box-orient': 'vertical',
-                    mark: {
-                      background: 'none',
-                      fontWeight: '600',
-                    },
-                  }}
-                  aria-label={result.summary}
-                >
-                  <HighlightText query={query} text={result.summary} />
-                </p>
-              )}
+              <ResultVisualContent query={query} result={result} />
+              <VisuallyHidden>
+                <p>{result.title}.</p>
+                {result.summary && <p>{result.summary}</p>}
+              </VisuallyHidden>
             </GatsbyLink>
           </li>
         ))}
@@ -317,6 +290,51 @@ function KeyboardControlIntructions() {
     <React.Fragment>
       <kbd>tab</kbd> to navigate, <kbd>enter</kbd> to select, <kbd>esc</kbd> to
       dismiss
+    </React.Fragment>
+  )
+}
+
+/**
+ * Display the content visually, with highlighting markup and all.
+ * This is great for sighted users, but it is problematic for users
+ * of screen readers since the phrase is broken up when read by
+ * some screen readers.
+ */
+function ResultVisualContent({ query, result }) {
+  return (
+    <React.Fragment>
+      <p
+        data-title
+        css={{
+          ...TYPOGRAPHY['XS'],
+          mark: {
+            background: COLORS.maize['200'] + '!important',
+            fontWeight: '700',
+          },
+        }}
+        aria-hidden="true"
+      >
+        <HighlightText query={query} text={result.title} />
+      </p>
+      {result.summary && (
+        <p
+          css={{
+            display: '-webkit-box',
+            color: COLORS.neutral['300'],
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            '-webkit-line-clamp': '2',
+            '-webkit-box-orient': 'vertical',
+            mark: {
+              background: 'none',
+              fontWeight: '600',
+            },
+          }}
+          aria-hidden="true"
+        >
+          <HighlightText query={query} text={result.summary} />
+        </p>
+      )}
     </React.Fragment>
   )
 }

--- a/src/components/site-search.js
+++ b/src/components/site-search.js
@@ -250,10 +250,6 @@ function ResultsList({ searching, noResults, results, query, error }) {
             key={index}
             value={result.title}
             css={{
-              mark: {
-                fontWeight: '700',
-                background: COLORS.maize['200'],
-              },
               ':not(:last-child)': {
                 borderBottom: `solid 1px ${COLORS.neutral['100']}`,
               },
@@ -280,6 +276,10 @@ function ResultsList({ searching, noResults, results, query, error }) {
                 data-title
                 css={{
                   ...TYPOGRAPHY['XS'],
+                  mark: {
+                    background: COLORS.maize['200'] + '!important',
+                    fontWeight: '700',
+                  },
                 }}
                 aria-label={result.title + '.'}
               >
@@ -294,6 +294,10 @@ function ResultsList({ searching, noResults, results, query, error }) {
                     textOverflow: 'ellipsis',
                     '-webkit-line-clamp': '2',
                     '-webkit-box-orient': 'vertical',
+                    mark: {
+                      background: 'none',
+                      fontWeight: '600',
+                    },
                   }}
                   aria-label={result.summary}
                 >

--- a/src/components/site-search.js
+++ b/src/components/site-search.js
@@ -94,11 +94,15 @@ export default function SiteSearch({ label }) {
 
   const handleChange = e => setQuery(e.target.value)
   return (
-    <div
+    <form
       css={{
         position: 'relative',
         display: 'flex',
         alignItems: 'center',
+      }}
+      onSubmit={e => {
+        e.preventDefault()
+        setOpenResults(true)
       }}
     >
       <Icon
@@ -156,7 +160,7 @@ export default function SiteSearch({ label }) {
         error={error}
         openResults={openResults}
       />
-    </div>
+    </form>
   )
 }
 

--- a/src/components/site-search.js
+++ b/src/components/site-search.js
@@ -21,6 +21,7 @@ export default function SiteSearch({ label }) {
   const [query, setQuery] = useState('')
   const [error, setError] = useState(null)
   const [results, setResults] = useState([])
+  const [openResults, setOpenResults] = useState([])
 
   useGoogleTagManager({
     eventName: 'siteSearch',
@@ -28,6 +29,11 @@ export default function SiteSearch({ label }) {
   })
 
   useEffect(() => {
+    // If the query changes, let results open again.
+    if (!openResults) {
+      setOpenResults(true)
+    }
+
     if (!query || !window.__LUNR__) {
       setResults([])
       return
@@ -70,6 +76,21 @@ export default function SiteSearch({ label }) {
       }
     }
   }, [query])
+
+  function handleKeydown(e) {
+    if (e.keyCode === 27) {
+      // ESC key
+      setOpenResults(false)
+    }
+  }
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeydown)
+
+    return () => {
+      document.addEventListener('keydown', handleKeydown)
+    }
+  })
 
   const handleChange = e => setQuery(e.target.value)
   return (
@@ -129,7 +150,12 @@ export default function SiteSearch({ label }) {
         />
       </label>
 
-      <ResultsContainer results={results} query={query} error={error} />
+      <ResultsContainer
+        results={results}
+        query={query}
+        error={error}
+        openResults={openResults}
+      />
     </div>
   )
 }
@@ -148,9 +174,13 @@ function ResultsSummary({ searching, noResults, resultCount }) {
   )
 }
 
-function ResultsContainer({ results, query, error }) {
+function ResultsContainer({ results, query, error, openResults }) {
   const searching = query.length > 0
   const noResults = searching && results.length === 0
+
+  if (!openResults) {
+    return null
+  }
 
   return (
     <React.Fragment>

--- a/src/components/site-search.js
+++ b/src/components/site-search.js
@@ -235,6 +235,7 @@ function ResultsList({ searching, noResults, results, query, error }) {
             boxShadow: `0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset;`,
           },
         }}
+        aria-hidden="true"
         data-site-search-keyboard-instructions
       >
         <KeyboardControlIntructions />

--- a/src/components/site-search.js
+++ b/src/components/site-search.js
@@ -265,18 +265,13 @@ function ResultsList({ searching, noResults, results, query, error }) {
                   background: COLORS.teal['100'],
                   borderLeft: `solid 4px ${COLORS.teal['400']}`,
                   paddingLeft: `calc(${SPACING['L']} - 4px)`,
-
                   '[data-title]': {
                     textDecoration: 'underline',
                   },
                 },
               }}
             >
-              <ResultVisualContent query={query} result={result} />
-              <VisuallyHidden>
-                <p>{result.title}.</p>
-                {result.summary && <p>{result.summary}</p>}
-              </VisuallyHidden>
+              <ResultContent query={query} result={result} />
             </GatsbyLink>
           </li>
         ))}
@@ -294,13 +289,7 @@ function KeyboardControlIntructions() {
   )
 }
 
-/**
- * Display the content visually, with highlighting markup and all.
- * This is great for sighted users, but it is problematic for users
- * of screen readers since the phrase is broken up when read by
- * some screen readers.
- */
-function ResultVisualContent({ query, result }) {
+function ResultContent({ query, result }) {
   return (
     <React.Fragment>
       <p
@@ -312,7 +301,6 @@ function ResultVisualContent({ query, result }) {
             fontWeight: '700',
           },
         }}
-        aria-hidden="true"
       >
         <HighlightText query={query} text={result.title} />
       </p>
@@ -330,7 +318,6 @@ function ResultVisualContent({ query, result }) {
               fontWeight: '600',
             },
           }}
-          aria-hidden="true"
         >
           <HighlightText query={query} text={result.summary} />
         </p>
@@ -344,8 +331,13 @@ function ResultVisualContent({ query, result }) {
  * matching and non-matching segments of text.
  */
 function HighlightText({ query, text }) {
+  // Escape regexp special characters in `str`
+  function escapeRegexp(str) {
+    return String(str).replace(/([.*+?=^!:${}()|[\]/\\])/g, '\\$1')
+  }
+
   const chunks = findAll({
-    searchWords: query.split(/\s+/),
+    searchWords: escapeRegexp(query || '').split(/\s+/),
     textToHighlight: text,
   })
 


### PR DESCRIPTION
Summary of changes:
- The ReachUI combobox has been removed completely, based on findings and discussion about how it is problematic. Main issue being a combobox is meant for suggesting a query and not for suggesting results.
- Updated input element label so that it describes how to access results.
- Added a visually hidden aria alert that says the number of results, eg "42 results". This changes and updates as your query then results change.
- Had to re-implement the text highlighting, because this was something provided by ReachUI, but now we're highlighting result description text too, where before it was just  just the result title.
