### PR TITLE
Add `allow: "/"` to prod robots.txt config.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -40,7 +40,7 @@ module.exports = {
         },
         env: {
           production: {
-            policy: [{ userAgent: '*' }],
+            policy: [{ userAgent: '*', allow: '/' }],
           },
           development: {
             policy: [{ userAgent: '*', disallow: '/' }],


### PR DESCRIPTION
Adds ` allow: '/' ` to the production `robot.txt` configuration.