### PR TITLE
Update header media queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@reach/combobox": "^0.8.5",
     "@reach/dialog": "^0.8.5",
     "@reach/visually-hidden": "^0.8.2",
-    "@reach/window-size": "^0.8.5",
     "@umich-lib/components": "^1.0.3",
     "@umich-lib/core": "^2.0.6",
     "gatsby": "^2.23.1",

--- a/src/components/header/header-largescreen.js
+++ b/src/components/header/header-largescreen.js
@@ -10,6 +10,10 @@ export default ({ primary, secondary }) => (
   <header
     css={{
       borderBottom: `solid 2px ${COLORS.neutral[100]}`,
+      display: 'block',
+      '@media only screen and (max-width: 1128px)': {
+        display: 'none',
+      },
     }}
   >
     <Margins>

--- a/src/components/header/header-smallscreen.js
+++ b/src/components/header/header-smallscreen.js
@@ -60,6 +60,10 @@ function SmallScreenHeader({ primary, secondary }) {
       <header
         css={{
           borderBottom: `solid 2px ${COLORS.neutral['100']}`,
+          display: 'block',
+          '@media only screen and (min-width: 1129px)': {
+            display: 'none',
+          },
         }}
       >
         <Margins>

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -5,26 +5,8 @@ import HeaderSmallScreen from './header-smallscreen'
 function Header({ primary, secondary }) {
   return (
     <React.Fragment>
-      <div
-        css={{
-          display: 'block',
-          '@media only screen and (min-width: 1129px)': {
-            display: 'none',
-          },
-        }}
-      >
-        <HeaderSmallScreen primary={primary} secondary={secondary} />
-      </div>
-      <div
-        css={{
-          display: 'block',
-          '@media only screen and (max-width: 1128px)': {
-            display: 'none',
-          },
-        }}
-      >
-        <HeaderLargeScreen primary={primary} secondary={secondary} />
-      </div>
+      <HeaderSmallScreen primary={primary} secondary={secondary} />
+      <HeaderLargeScreen primary={primary} secondary={secondary} />
     </React.Fragment>
   )
 }

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,17 +1,32 @@
 import React from 'react'
-import { useWindowSize } from '@reach/window-size'
-
 import HeaderLargeScreen from './header-largescreen'
 import HeaderSmallScreen from './header-smallscreen'
 
 function Header({ primary, secondary }) {
-  const { width } = useWindowSize()
-
-  if (width > 1129) {
-    return <HeaderLargeScreen primary={primary} secondary={secondary} />
-  }
-
-  return <HeaderSmallScreen primary={primary} secondary={secondary} />
+  return (
+    <React.Fragment>
+      <div
+        css={{
+          display: 'block',
+          '@media only screen and (min-width: 1129px)': {
+            display: 'none',
+          },
+        }}
+      >
+        <HeaderSmallScreen primary={primary} secondary={secondary} />
+      </div>
+      <div
+        css={{
+          display: 'block',
+          '@media only screen and (max-width: 1128px)': {
+            display: 'none',
+          },
+        }}
+      >
+        <HeaderLargeScreen primary={primary} secondary={secondary} />
+      </div>
+    </React.Fragment>
+  )
 }
 
 export default Header


### PR DESCRIPTION
This change replaces `@reach/window-size` used to decide what header to display in favor of a media query CSS solution. In previous attempts, we had issues with re-hydration causing a white-screen, but that has been avoided with this implementation.