### PR TITLE
www.lib -- use rel="canonical" link tag 

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -62,6 +62,8 @@ module.exports = {
               {
                 userAgent: '*',
                 disallow: ['/'],
+                host: null,
+                sitemap: null,
               },
             ],
           },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -23,6 +23,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-robots-txt',
       options: {
+        host: siteMetadata.siteUrl,
         sitemap: siteMetadata.siteUrl + '/sitemap.xml',
         resolveEnv: () => {
           /**
@@ -49,10 +50,20 @@ module.exports = {
         },
         env: {
           production: {
-            policy: [{ userAgent: '*', allow: '/' }],
+            policy: [
+              {
+                userAgent: '*',
+                allow: '/',
+              },
+            ],
           },
           development: {
-            policy: [{ userAgent: '*', disallow: '/' }],
+            policy: [
+              {
+                userAgent: '*',
+                disallow: ['/'],
+              },
+            ],
           },
         },
       },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,7 +4,7 @@ console.log(`Using DRUPAL_URL: '${DRUPAL_URL}'`)
 
 const siteMetadata = {
   title: 'University of Michigan Library',
-  siteUrl: 'https://lib.umich.edu',
+  siteUrl: 'https://www.lib.umich.edu',
 }
 
 module.exports = {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -23,7 +23,6 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-robots-txt',
       options: {
-        host: siteMetadata.siteUrl,
         sitemap: siteMetadata.siteUrl + '/sitemap.xml',
         resolveEnv: () => {
           /**
@@ -56,6 +55,12 @@ module.exports = {
             policy: [{ userAgent: '*', disallow: '/' }],
           },
         },
+      },
+    },
+    {
+      resolve: `gatsby-plugin-react-helmet-canonical-urls`,
+      options: {
+        siteUrl: siteMetadata.siteUrl,
       },
     },
     'gatsby-transformer-sharp',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12327,6 +12327,14 @@
         "@babel/runtime": "^7.7.4"
       }
     },
+    "gatsby-plugin-react-helmet-canonical-urls": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet-canonical-urls/-/gatsby-plugin-react-helmet-canonical-urls-1.4.0.tgz",
+      "integrity": "sha512-5g2eqFNh8GSCTvL25sNm84IJ6G79qKHSnOa9druxBj6x5Iw3EujZMv6I4nGMlW5EZlaSf9D5QHNGypUW6idPTg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1"
+      }
+    },
     "gatsby-plugin-remove-serviceworker": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-remove-serviceworker/-/gatsby-plugin-remove-serviceworker-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gatsby-plugin-manifest": "^2.3.6",
     "gatsby-plugin-netlify": "^2.1.28",
     "gatsby-plugin-react-helmet": "^3.1.16",
+    "gatsby-plugin-react-helmet-canonical-urls": "^1.4.0",
     "gatsby-plugin-robots-txt": "^1.5.1",
     "gatsby-plugin-sharp": "^2.5.6",
     "gatsby-plugin-sitemap": "^2.4.10",

--- a/src/templates/news.js
+++ b/src/templates/news.js
@@ -114,7 +114,7 @@ export default function NewsTemplate({ data }) {
           )}
 
           <Share
-            url={'https://lib.umich.edu' + slug}
+            url={'https://www.lib.umich.edu' + slug}
             title={field_title_context}
           />
           <StayInTheKnow />


### PR DESCRIPTION
This change updates a few remaining URLs to use `www.lib` to avoid redirects and adds a canonical link to each page so that search engines know the correct link to use to scrape data and link when the page comes up in search results.

```html
<!-- Exists on every build of the website when at the `/ask-librarian` page -->
<link rel="canonical" href="https://www.lib.umich.edu/ask-librarian">
```

This change is based on [Google's recommendations to use rel="canonical" link tag](https://support.google.com/webmasters/answer/139066?hl=en).