### PR TITLE
`_redirects` file cleanup

### DIFF
--- a/plugins/gatsby-source-umich-lib/create-redirects.js
+++ b/plugins/gatsby-source-umich-lib/create-redirects.js
@@ -70,34 +70,3 @@ async function createNetlifyRedirectsFile({ baseUrl }) {
 }
 
 exports.createNetlifyRedirectsFile = createNetlifyRedirectsFile
-
-function createClientSideRedirects({ createRedirect }) {
-  if (!createRedirect) {
-    throw 'createClientSideRedirects requires createRedirect arg'
-  }
-
-  const readInterface = readline.createInterface({
-    input: fs.createReadStream('public/_redirects'),
-  })
-
-  readInterface.on('line', function(line) {
-    if (line) {
-      const lineCopy = line.slice()
-      const urls = lineCopy.split(' ')
-      /**
-       * Creating client-side redirect from ' + urls[0] + ' to ' + urls[1]
-       */
-      createRedirect({
-        fromPath: urls[0],
-        toPath: urls[1],
-        isPermanent: true,
-        redirectInBrowser: true,
-        force: true,
-      })
-    }
-  })
-
-  console.log('Created back-up client-side redirects.')
-}
-
-exports.createClientSideRedirects = createClientSideRedirects

--- a/plugins/gatsby-source-umich-lib/gatsby-node.js
+++ b/plugins/gatsby-source-umich-lib/gatsby-node.js
@@ -206,12 +206,6 @@ exports.onCreateNode = async ({ node, actions }, { baseUrl }) => {
 exports.createPages = ({ actions, graphql }, { baseUrl }) => {
   const { createPage } = actions
 
-  /**
-   * This is a useful backup if the server-side redirects ever fail.
-   * Redirects are very important!
-   */
-  createClientSideRedirects({ createRedirect: actions.createRedirect })
-
   return new Promise((resolve, reject) => {
     const basicTemplate = path.resolve(`src/templates/basic.js`)
     const fullWidthTemplate = path.resolve(`src/templates/fullwidth.js`)


### PR DESCRIPTION
## What's changed?

- Fix inconsistencies in how many redirects are processed. Netlify was processing about 2x as many rules as actually have on subsequent builds.
- Adds validation for the _redirects file, so that the build fails if it doesn't find the first expected redirect.
