### PR TITLE
News landing page updates -- LIBWEB-786

### DIFF
--- a/src/components/panels/whats-happening-panel.js
+++ b/src/components/panels/whats-happening-panel.js
@@ -4,7 +4,6 @@ import { SPACING, MEDIA_QUERIES, Heading, Margins } from '@umich-lib/core'
 import Link from '../link'
 import EventCard from '../event-card'
 import { sortEventsByStartDate } from '../../utils/events'
-import * as moment from 'moment'
 
 /*
   Featured and latest news and exhibits.
@@ -72,7 +71,7 @@ export default function WhatsHappening() {
 
       setEvents(sortedEvents.slice(0, 3)) // only keep 3
     }
-  }, [events])
+  }, [events]) // eslint-disable-line
 
   // Make sure there are events to render.
   if (!events || events.length === 0) {

--- a/src/templates/news-landing.js
+++ b/src/templates/news-landing.js
@@ -28,6 +28,7 @@ export default function NewsLandingTemplate({ data }) {
   )
   const newsLibraryUpdates = processNewsData(data.newsLibraryUpdates)
   const newsMainInitialShow = 10
+  const newsLibraryUpdatesInitialShow = 20
 
   const {
     title,
@@ -115,22 +116,33 @@ export default function NewsLandingTemplate({ data }) {
             Library Updates
           </Heading>
           {newsLibraryUpdates && (
-            <ol>
-              {newsLibraryUpdates.map((item, i) => (
-                <li
-                  key={'news-item-' + i}
-                  css={{
-                    marginBottom: SPACING['XL'],
-                  }}
-                >
-                  <Card
-                    href={item.href}
-                    title={item.title}
-                    subtitle={item.subtitle}
-                  />
-                </li>
-              ))}
-            </ol>
+            <Expandable>
+              <ol>
+                <ExpandableChildren show={newsLibraryUpdatesInitialShow}>
+                  {newsLibraryUpdates.map((item, i) => (
+                    <li
+                      key={'news-item-' + i}
+                      css={{
+                        marginBottom: SPACING['XL'],
+                      }}
+                    >
+                      <Card
+                        href={item.href}
+                        title={item.title}
+                        subtitle={item.subtitle}
+                      />
+                    </li>
+                  ))}
+                </ExpandableChildren>
+              </ol>
+
+              {newsLibraryUpdates.length > newsLibraryUpdatesInitialShow && (
+                <ExpandableButton
+                  name="updates"
+                  count={newsLibraryUpdates.length}
+                />
+              )}
+            </Expandable>
           )}
         </TemplateSide>
       </Template>

--- a/src/templates/news-landing.js
+++ b/src/templates/news-landing.js
@@ -27,7 +27,7 @@ export default function NewsLandingTemplate({ data }) {
     processNewsData(data.restNews)
   )
   const newsLibraryUpdates = processNewsData(data.newsLibraryUpdates)
-  const newsMainInitialShow = 15
+  const newsMainInitialShow = 10
 
   const {
     title,


### PR DESCRIPTION
- Reduced the number of main news items that appear initially from 15 to 10.
- Add a "Show all" button to the Library Updates column after 20 items.