### PR TITLE
Add "Referrer-Policy: no-referrer-when-downgrade" to Netlify header config.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,8 @@
 
 [[plugins]]
   package = "netlify-plugin-gatsby-cache"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Referrer-Policy = "no-referrer-when-downgrade"


### PR DESCRIPTION
```
Referrer-Policy: no-referrer-when-downgrade
```

This change is in response to allow libraryh3lp.com to receive a Referer header, so that Ask a Librarian staff can see what page the user is on to provide better support.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy