### PR TITLE
Display each event occurrence -- LIBWEB-792

### DIFF
--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -107,7 +107,31 @@ export function sortEventsByStartDate({ events, onlyTodayOrAfter = false }) {
   const uniqueEvents = [...events].filter(
     (v, i, a) => a.findIndex(t => t.id === v.id) === i
   )
-  const sortedEvents = [...uniqueEvents].sort(compareStartDate)
+
+  // Duplicate events that have many occurances by
+  // checking if it has many datetimes.
+  let occurances = []
+  uniqueEvents.forEach(event => {
+    const hasOccurances = event.field_event_date_s_.length > 1
+
+    if (hasOccurances) {
+      const dates = event.field_event_date_s_
+
+      // Make an event in the array for each date.
+      dates.forEach((date, i) => {
+        occurances = occurances.concat([
+          {
+            ...event,
+            field_event_date_s_: [date], // The one occurance
+          },
+        ])
+      })
+    } else {
+      occurances = occurances.concat([event])
+    }
+  })
+
+  const sortedEvents = [...occurances].sort(compareStartDate)
 
   function compareStartDate(a, b) {
     const startA = a.field_event_date_s_[0].value


### PR DESCRIPTION
## What's up?

An event can have many dates or occurrences. Below is an example:

![Screen Shot 2021-02-01 at 14 05 24](https://user-images.githubusercontent.com/1678665/106505735-b6d1b200-6496-11eb-84e4-d738bbc2487f.png)

This change makes each occurrence display in the list of events, such as under "Upcoming Events" for [Events and Exhibits](https://lib.umich.edu/visit-and-study/events-and-exhibits/today-and-upcoming). Before it would only display the first occurrence in display lists.

Preview of change:

![Screen Shot 2021-02-01 at 14 06 19](https://user-images.githubusercontent.com/1678665/106505749-b9cca280-6496-11eb-9fb8-a806ef70c9a6.png)

Compare production and the build preview to compare as well.
