### PR TITLE
Bugfix: Only focus on h1 when new location pathname.

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -36,10 +36,19 @@ export const wrapPageElement = ({ element }) => {
   )
 }
 
-export const onRouteUpdate = ({ prevLocation }) => {
+export const onRouteUpdate = ({ location, prevLocation }) => {
+  const newPath = location.pathname
   const oldPath = prevLocation ? prevLocation.pathname : null
 
-  if (oldPath) {
+  /**
+   * We shouldn't handle paths that are only
+   * query params. eg, Staff Directory or
+   * Find a Specialist searches. Otherwise the
+   * focus would change on every key stroke.
+   *
+   * Is there a new path?
+   */
+  if (newPath !== oldPath) {
     const dataPageHeading = document.querySelector('[data-page-heading]')
     const h1 = document.querySelector('h1')
     const pageHeading = dataPageHeading ? dataPageHeading : h1


### PR DESCRIPTION
This fixes an issue with the logic that handles focusing to the h1 on page route. To replicate the issue, enter a query on the production [Staff Directory](https://www.lib.umich.edu/about-us/staff-directory) and [Find a Specialist](https://www.lib.umich.edu/research-and-scholarship/help-research/find-specialist) and you'll notice as you type the focus going to the h1.

In the deploy preview, you should see this resolved/fixed.