### PR TITLE
Add uniqname to site search for improved staff results.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -136,14 +136,19 @@ module.exports = {
         languages: [{ name: 'en' }],
         fields: [
           {
+            name: 'uniqname',
+            store: true,
+            attributes: { boost: 3 },
+          },
+          {
             name: 'title',
             store: true,
-            attributes: { boost: 9 },
+            attributes: { boost: 3 },
           },
           {
             name: 'summary',
             store: true,
-            attributes: { boost: 3 },
+            attributes: { boost: 2 },
           },
           {
             name: 'keywords',
@@ -152,6 +157,7 @@ module.exports = {
         ],
         resolvers: {
           SitePage: {
+            uniqname: node => (node.context ? node.context.uniqname : null),
             title: node => (node.context ? node.context.title : null),
             summary: node => (node.context ? node.context.summary : null),
             keywords: node => (node.context ? node.context.keywords : null),

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -136,19 +136,19 @@ module.exports = {
         languages: [{ name: 'en' }],
         fields: [
           {
-            name: 'uniqname',
-            store: true,
-            attributes: { boost: 3 },
-          },
-          {
             name: 'title',
             store: true,
-            attributes: { boost: 3 },
+            attributes: { boost: 9 },
+          },
+          {
+            name: 'uniqname',
+            store: true,
+            attributes: { boost: 6 },
           },
           {
             name: 'summary',
             store: true,
-            attributes: { boost: 2 },
+            attributes: { boost: 3 },
           },
           {
             name: 'keywords',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -141,17 +141,16 @@ module.exports = {
             attributes: { boost: 9 },
           },
           {
-            name: 'uniqname',
-            store: true,
-            attributes: { boost: 6 },
-          },
-          {
             name: 'summary',
             store: true,
             attributes: { boost: 3 },
           },
           {
             name: 'keywords',
+            store: true,
+          },
+          {
+            name: 'uniqname',
             store: true,
           },
         ],

--- a/plugins/gatsby-source-umich-lib/gatsby-node.js
+++ b/plugins/gatsby-source-umich-lib/gatsby-node.js
@@ -662,7 +662,8 @@ exports.createPages = ({ actions, graphql }, { baseUrl }) => {
               name: node.name,
               title: node.field_user_display_name,
               summary: node.field_user_work_title, // used for site search
-              isProfile: true,
+              uniqname: node.name,
+              kind: 'user',
             },
           })
         })


### PR DESCRIPTION
## What's up?

We did not include uniqname in the site search index for searching, but we found through feedback that staff expects this functionality. It also improves some situations where stemming gave results in an order that was unexpected. 

## Result

**before**
![before](https://user-images.githubusercontent.com/1678665/108249522-2c8a7e80-7123-11eb-9b62-981da2738b2a.png)

**after**
![after](https://user-images.githubusercontent.com/1678665/108249547-357b5000-7123-11eb-918a-0ac72d976830.png)
