### PR TITLE
Changing "Department information" to "Who we are"

### DIFF
--- a/src/templates/department.js
+++ b/src/templates/department.js
@@ -78,7 +78,7 @@ function DepartmentTemplate({ data }) {
             </Heading>
             <Prose>
               <Heading size="M" level={2}>
-                Department information
+                Who we are
               </Heading>
 
               <List


### PR DESCRIPTION
# Overview
The "Department information" heading on department pages has been changed to "Who we are."

## Testing
* Check all pages under [Our Divisions and Departments](https://deploy-preview-154--umich-lib.netlify.app/about-us/our-divisions-and-departments) and see that "Department information" has been changed to "Who we are."