### PR TITLE
Updating footer zip code

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -22,7 +22,7 @@ const links = [
           <React.Fragment>
             913 S. University Avenue
             <br />
-            Ann Arbor, MI 48109
+            Ann Arbor, MI 48109-1190
           </React.Fragment>
         ),
         to: locationURL,


### PR DESCRIPTION
# Overview
The zip code for the address in the footer needs to include the full 9-digit zip code because the extension is needed for campus mail.