### PR TITLE
Quickfix: Text panel missing from certain pages.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 const DRUPAL_URL = process.env.DRUPAL_URL || 'https://cms.lib.umich.edu/'
 const DRUPAL_CONCURRENT_FILE_REQUESTS =
-  parseInt(process.env.DRUPAL_CONCURRENT_FILE_REQUESTS) || 10
+  parseInt(process.env.DRUPAL_CONCURRENT_FILE_REQUESTS) || 3
 
 console.log('[gatsby-config] ENV VARs')
 console.log(`DRUPAL_URL='${DRUPAL_URL}'`)

--- a/src/graphql/textPanelFragment.js
+++ b/src/graphql/textPanelFragment.js
@@ -2,6 +2,7 @@ import { graphql } from 'gatsby'
 
 export const query = graphql`
   fragment textPanelFragment on paragraph__text_panel {
+    __typename
     field_title
     id
     field_placement


### PR DESCRIPTION
It appears with the upgrade from Gatsby v2 to v3 graphql fragments were missing `__typename`. Adding this in at the fragment fixes that issue.