### PR TITLE
[LIBWEB-842] Fix Events + Exhibits "where" display for cards

### DIFF
--- a/src/components/event-card.js
+++ b/src/components/event-card.js
@@ -109,7 +109,7 @@ export default function EventCard(node) {
               }}
             >
               <span className="visually-hidden">Where: </span>
-              {where.map(item => item.label)}
+              {where.map(item => item.label).join("; ")}
             </span>
           </span>
           {!isAnExhibit && (

--- a/src/templates/event.js
+++ b/src/templates/event.js
@@ -197,7 +197,7 @@ function EventMetadata({ data }) {
   const where = eventFormatWhere({
     node: data,
     kind: 'full',
-  })
+  }, true)
 
   return (
     <table

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -87,7 +87,7 @@ export function eventFormatWhen({ start, end, kind, type }) {
   )
 }
 
-export function eventFormatWhere({ node, kind }) {
+export function eventFormatWhere({ node, kind }, includeLink = false) {
   let where = []
 
   if (node.field_event_online) {
@@ -96,7 +96,7 @@ export function eventFormatWhere({ node, kind }) {
    })
   }
 
-  if (node.field_online_event_link) {
+  if (includeLink && node.field_online_event_link) {
     where.push({
       label: node.field_online_event_link.title,
       href: node.field_online_event_link.uri


### PR DESCRIPTION
# Overview
Events are now pulling in information that the event will be online and/or in a building. If there is a link for the event, the link will also display. As a result, the link text was being included in the `EventCard` component. This pull request filters out the links for the cards, and only display them in the `event` template itself.

Before:

![image](https://user-images.githubusercontent.com/27687379/146835649-d38212c3-9bfe-413a-a633-e42e1b68c14c.png)

After:

![Screen Shot 2021-12-20 at 4 34 03 PM](https://user-images.githubusercontent.com/27687379/146835665-f726bb23-391e-4f99-838c-1248ece98b6b.png)

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools