### PR TITLE
[LIBWEB-840] Add Location CT to lookup for Events + Exhibits templates

### DIFF
--- a/src/graphql/eventFragment.js
+++ b/src/graphql/eventFragment.js
@@ -76,6 +76,7 @@ export const query = graphql`
         }
       }
       field_event_room {
+        ...locationFragment
         ...roomFragment
       }
       field_event_building {


### PR DESCRIPTION
# Overview
The `Events and Exhibits` content type has an `Event Room` custom field that displays a list of radio buttons that come from both the `Room` content type and `Location` content type. If a selected option came from the `Location` content type, the received information was an empty `Object`. This pull request updates the `graphQL` to receive the `Location` information so the `title` can actually be displayed.

This pull request resolves [LIBWEB-840](https://tools.lib.umich.edu/jira/browse/LIBWEB-840)

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Compare [production](https://lib.umich.edu/visit-and-study/events-and-exhibits/today-and-upcoming/dutch-studies-decolonial-revision) vs. [localhost](http://localhost:8000/visit-and-study/events-and-exhibits/today-and-upcoming/dutch-studies-decolonial-revision).
  - Does `WHERE` now say `Hatcher North Lobby Cases, Hatcher Library North` instead of `, Hatcher Library North`?