### PR TITLE
Wrapping fragments with `...on Node`

### DIFF
--- a/src/graphql/eventFragment.js
+++ b/src/graphql/eventFragment.js
@@ -76,8 +76,11 @@ export const query = graphql`
         }
       }
       field_event_room {
-        ...locationFragment
-        ...roomFragment
+        ... on Node {
+          __typename
+          ...locationFragment
+          ...roomFragment
+        }
       }
       field_event_building {
         ...buildingFragment


### PR DESCRIPTION
# Overview
Staging and production builds failed because of `GraphQLError: Fragment "locationFragment" cannot be spread here as objects of   type "node__room" can never be of type "node__location".`. Wrapping the fragments may help.