### PR TITLE
[LIBWEB-852] Hours not displaying :30 

### DIFF
--- a/src/graphql/hoursFragment.js
+++ b/src/graphql/hoursFragment.js
@@ -145,7 +145,6 @@ export const query = graphql`
         day
         starthours
         endhours
-        comment
       }
     }
     ... on paragraph__july_4_holiday_hours {
@@ -206,7 +205,6 @@ export const query = graphql`
         day
         starthours
         endhours
-        comment
       }
     }
   }

--- a/src/utils/hours.js
+++ b/src/utils/hours.js
@@ -118,29 +118,27 @@ export function displayHours({ node, now }) {
 
   const { starthours, endhours, comment } = hoursForNow;
 
-  if (comment) {
-    return {
-      text: comment,
-      label: comment,
-    };
-  }
-
-  // Needs to be 24 time format, ie ####.
-  const start = starthours < 1000 ? '0' + starthours : starthours;
-  const end = endhours < 1000 ? '0' + endhours : endhours;
-
-  if (start === end) {
+  if (!comment && starthours === endhours) {
     return null;
   }
 
-  const showTime = (time) => {
-    const minutes = time.toString().slice(2);
-    const timeFormat = minutes === '00' ? 'ha' : 'h:mma';
-    return moment(time, 'HHmm').format(timeFormat);
-  }
+  let [text, label] = [comment];
 
-  const text = `${showTime(start)} - ${showTime(end)}`;
-  const label = `${showTime(start)} to ${showTime(end)}`;
+  if (starthours !== endhours) {
+    const convertTo24Hour = (time) => {
+      return time < 1000 ? '0' + time : time;
+    };
+  
+    const formatTime = (time) => {
+      const setTime = convertTo24Hour(time);
+      const minutes = setTime.toString().slice(2);
+      const timeFormat = minutes === '00' ? 'ha' : 'h:mma';
+      return moment(setTime, 'HHmm').format(timeFormat);
+    }
+  
+    text = [`${formatTime(starthours)} - ${formatTime(endhours)}`, text].filter(Boolean).join(', ');
+    label = [`${formatTime(starthours)} to ${formatTime(endhours)}`, label].filter(Boolean).join(', ');
+  }
 
   return {
     text,

--- a/src/utils/hours.js
+++ b/src/utils/hours.js
@@ -125,15 +125,11 @@ export function displayHours({ node, now }) {
   let [text, label] = [comment];
 
   if (starthours !== endhours) {
-    const convertTo24Hour = (time) => {
-      return time < 1000 ? '0' + time : time;
-    };
-  
     const formatTime = (time) => {
-      const setTime = convertTo24Hour(time);
-      const minutes = setTime.toString().slice(2);
-      const timeFormat = minutes === '00' ? 'ha' : 'h:mma';
-      return moment(setTime, 'HHmm').format(timeFormat);
+      const time24Hours = time < 1000 ? '0' + time : time;
+      const getMinutes = time24Hours.toString().slice(2);
+      const setTimeFormat = getMinutes === '00' ? 'ha' : 'h:mma';
+      return moment(time24Hours, 'HHmm').format(setTimeFormat);
     }
   
     text = [`${formatTime(starthours)} - ${formatTime(endhours)}`, text].filter(Boolean).join(', ');

--- a/src/utils/hours.js
+++ b/src/utils/hours.js
@@ -131,9 +131,13 @@ export function displayHours({ node, now }) {
       const setTimeFormat = getMinutes === '00' ? 'ha' : 'h:mma';
       return moment(time24Hours, 'HHmm').format(setTimeFormat);
     }
+
+    const combinedValues = (separator = 'to') => {
+      return [`${formatTime(starthours)} ${separator} ${formatTime(endhours)}`, comment].filter(Boolean).join(', ');
+    };
   
-    text = [`${formatTime(starthours)} - ${formatTime(endhours)}`, text].filter(Boolean).join(', ');
-    label = [`${formatTime(starthours)} to ${formatTime(endhours)}`, label].filter(Boolean).join(', ');
+    text = combinedValues('-');
+    label = combinedValues();
   }
 
   return {

--- a/src/utils/hours.js
+++ b/src/utils/hours.js
@@ -133,14 +133,14 @@ export function displayHours({ node, now }) {
     return null;
   }
 
-  const text =
-    moment(start, 'HHmm').format('ha') +
-    ' - ' +
-    moment(end, 'HHmm').format('ha');
-  const label =
-    moment(start, 'HHmm').format('ha') +
-    ' to ' +
-    moment(end, 'HHmm').format('ha');
+  const showTime = (time) => {
+    const minutes = time.toString().slice(2);
+    const timeFormat = minutes === '00' ? 'ha' : 'h:mma';
+    return moment(time, 'HHmm').format(timeFormat);
+  }
+
+  const text = `${showTime(start)} - ${showTime(end)}`;
+  const label = `${showTime(start)} to ${showTime(end)}`;
 
   return {
     text,

--- a/src/utils/hours.js
+++ b/src/utils/hours.js
@@ -127,7 +127,7 @@ export function displayHours({ node, now }) {
   if (starthours !== endhours) {
     const formatTime = (time) => {
       const time24Hours = time < 1000 ? '0' + time : time;
-      const getMinutes = time24Hours.toString().slice(2);
+      const getMinutes = time24Hours.toString().slice(-2);
       const setTimeFormat = getMinutes === '00' ? 'ha' : 'h:mma';
       return moment(time24Hours, 'HHmm').format(setTimeFormat);
     }


### PR DESCRIPTION
# Overview
The [Locations and Hours > Hours View](https://www.lib.umich.edu/locations-and-hours/hours-view) only showed the hour and ante meridiem if the `Comment` field was empty. The minutes now show if they are not `00`.

This pull request closes [LIBWEB-852](https://tools.lib.umich.edu/jira/browse/LIBWEB-852).

## Comments
Originally the values would return just the `comment` if it existed. Now the values will return the times, followed by the comment, if they both exist. 

## GraphQL
The `hoursFragment` query contains several `field_hours_open` listings. A couple of them had an extra `comment` listed, which have been removed.

## Testing
- Check [Art, Architecture, and Engineering Library](http://localhost:8000/locations-and-hours/hours-view#art-architecture-and-engineering-library), and view the week of `May 22 - May 28`. See if the minutes show under `Computer and Video Game Archive` under `FRI May 27`.