### PR TITLE
[WEBSITE-64] Popular Databases column break

### DIFF
--- a/src/components/panels/link-panel.js
+++ b/src/components/panels/link-panel.js
@@ -104,7 +104,12 @@ function DatabaseLinkList({ data }) {
         }}
       >
         {field_link.map((d, i) => (
-          <li key={d.title + i}>
+          <li
+            key={d.title + i}
+            css={{
+              breakInside: 'avoid'
+            }}
+          >
             <Link
               kind="list"
               to={d.uri}


### PR DESCRIPTION
> …the [Popular Databases list](https://www.lib.umich.edu/locations-and-hours/taubman-health-sciences-library) doesn't display as well in Firefox as it does in Chrome. Micromedex (Academic Use Only) is split over two columns, so the second column starts with "Use Only)".

This pull request closes [WEBSITE-64](https://mlit.atlassian.net/browse/WEBSITE-64)

Firefox:

![Screen Shot 2022-06-27 at 12 52 24 PM](https://user-images.githubusercontent.com/27687379/176001155-ac06e303-985f-4d8d-8daa-61025926df73.png)

Chrome:

![Screen Shot 2022-06-27 at 12 52 37 PM](https://user-images.githubusercontent.com/27687379/176001183-e605a218-0324-4976-8ba3-a6da90e4c6a3.png)