### PR TITLE
[WEBSITE-63] Featured image handling: Events and Exhibits template

### DIFF
--- a/src/components/panels/events-and-exhibits-panel.js
+++ b/src/components/panels/events-and-exhibits-panel.js
@@ -44,7 +44,7 @@ export default function EventsAndExhibitsPanel() {
       ) {
         edges {
           node {
-            ...eventFragment
+            ...eventCardFragment
           }
         }
       }

--- a/src/components/panels/whats-happening-panel.js
+++ b/src/components/panels/whats-happening-panel.js
@@ -32,7 +32,7 @@ export default function WhatsHappening() {
         }
       ) {
         nodes {
-          ...eventFragment
+          ...eventCardFragment
         }
       }
       otherEvents: allNodeEventsAndExhibits(
@@ -47,7 +47,7 @@ export default function WhatsHappening() {
         }
       ) {
         nodes {
-          ...eventFragment
+          ...eventCardFragment
         }
       }
     }

--- a/src/graphql/eventCardFragment.js
+++ b/src/graphql/eventCardFragment.js
@@ -17,47 +17,11 @@ export const query = graphql`
       end_value
     }
     field_event_online
-    field_online_event_link {
-      uri
-      title
-    }
-    field_event_in_non_library_locat
-    field_non_library_location_addre {
-      organization
-      locality
-      address_line1
-      address_line2
-      postal_code
-      administrative_area
-    }
     relationships {
-      field_library_contact {
-        field_user_display_name
-        field_user_email
-        name
-      }
-      field_non_library_event_contact {
-        field_first_name
-        field_last_name
-        field_email
-      }
-      field_library_contact {
-        field_user_display_name
-        field_user_email
-      }
-      field_event_series {
-        name
-      }
       field_event_type {
         name
       }
-      field_event_series {
-        name
-      }
       field_media_image {
-        field_image_caption {
-          processed
-        }
         relationships {
           field_media_image {
             localFile {

--- a/src/graphql/eventCardFragment.js
+++ b/src/graphql/eventCardFragment.js
@@ -1,0 +1,87 @@
+import { graphql } from 'gatsby';
+
+export const query = graphql`
+  fragment eventCardFragment on node__events_and_exhibits {
+    __typename
+    id
+    title
+    field_title_context
+    fields {
+      slug
+    }
+    body {
+      summary
+    }
+    field_event_date_s_ {
+      value
+      end_value
+    }
+    field_event_online
+    field_online_event_link {
+      uri
+      title
+    }
+    field_event_in_non_library_locat
+    field_non_library_location_addre {
+      organization
+      locality
+      address_line1
+      address_line2
+      postal_code
+      administrative_area
+    }
+    relationships {
+      field_library_contact {
+        field_user_display_name
+        field_user_email
+        name
+      }
+      field_non_library_event_contact {
+        field_first_name
+        field_last_name
+        field_email
+      }
+      field_library_contact {
+        field_user_display_name
+        field_user_email
+      }
+      field_event_series {
+        name
+      }
+      field_event_type {
+        name
+      }
+      field_event_series {
+        name
+      }
+      field_media_image {
+        field_image_caption {
+          processed
+        }
+        relationships {
+          field_media_image {
+            localFile {
+              childImageSharp {
+                gatsbyImageData(
+                  width: 320
+                  placeholder: NONE
+                  layout: CONSTRAINED
+                )
+              }
+            }
+          }
+        }
+      }
+      field_event_room {
+        ... on Node {
+          __typename
+          ...locationFragment
+          ...roomFragment
+        }
+      }
+      field_event_building {
+        ...buildingFragment
+      }
+    }
+  }
+`;

--- a/src/graphql/eventFragment.js
+++ b/src/graphql/eventFragment.js
@@ -68,7 +68,6 @@ export const query = graphql`
             localFile {
               childImageSharp {
                 gatsbyImageData(
-                  width: 320
                   placeholder: NONE
                   layout: CONSTRAINED
                 )

--- a/src/graphql/eventFragment.js
+++ b/src/graphql/eventFragment.js
@@ -11,7 +11,6 @@ export const query = graphql`
       breadcrumb
     }
     body {
-      summary
       processed
     }
     field_event_date_s_ {
@@ -26,15 +25,6 @@ export const query = graphql`
       uri
       title
     }
-    field_event_in_non_library_locat
-    field_non_library_location_addre {
-      organization
-      locality
-      address_line1
-      address_line2
-      postal_code
-      administrative_area
-    }
     relationships {
       field_library_contact {
         field_user_display_name
@@ -46,17 +36,10 @@ export const query = graphql`
         field_last_name
         field_email
       }
-      field_library_contact {
-        field_user_display_name
-        field_user_email
-      }
       field_event_series {
         name
       }
       field_event_type {
-        name
-      }
-      field_event_series {
         name
       }
       field_media_image {


### PR DESCRIPTION
# Overview
The featured images on the Event and Exhibit template are grainier than usual and shorter height because the image coming through measures around `420x230`. The image file sizes should be consistently `1185x790`. This is because `width: 320` was set for the featured images in `graphql`. This size was mainly for the `EventCard` component.

`eventFragment` has been duplicated to create `eventCardFragment`, which has then been applied to all files using the `EventCard` component. Then both queries were reduced to only contain data that is used in their designated templates and components to reduce load.