### PR TITLE
[WEBSITE-65] Add 2nd department affiliation to profile and Staff Directory?

### DIFF
--- a/src/templates/profile.js
+++ b/src/templates/profile.js
@@ -381,7 +381,7 @@ function ProfileHeader({
   relationships,
 }) {
   const { field_user_department } = relationships;
-  const depts = field_user_department.reverse();
+  const depts = [...field_user_department].reverse();
 
   return (
     <React.Fragment>
@@ -395,21 +395,16 @@ function ProfileHeader({
         {field_user_display_name}
       </Heading>
       {field_user_work_title && <Text lede>{field_user_work_title}</Text>}
-      {depts && (
-        <div>
-          {field_user_department[1] && (
-            <Link to={field_user_department[1].path.alias}>
-              {field_user_department[1].field_title_context}
+      {depts && depts.map((department, index) => {
+        return (
+          <span key={index}>
+            {index > 0 && ' · '}
+            <Link to={department.path.alias}>
+              {department.field_title_context}
             </Link>
-          )}
-          {field_user_department.length > 1 ? ' · ' : null}
-          {field_user_department[0] && (
-            <Link to={field_user_department[0].path.alias}>
-              {field_user_department[0].field_title_context}
-            </Link>
-          )}
-        </div>
-      )}
+          </span>
+        )
+      })}
     </React.Fragment>
   );
 }


### PR DESCRIPTION
# Overview
Profiles were originally limited to showing only a maximum of two affiliated departments. There are now members that work in more than two. This pull request removes that limitation and allows as many as the person is involved.