### PR TITLE
[WEBSITE-11] Extra bottom border between text panel and link panel

### DIFF
--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -34,9 +34,8 @@ function PanelTemplate({ title, children, shaded, ...rest }) {
       data-panel
       css={{
         background: shaded ? COLORS.blue['100'] : '',
-        borderBottom: shaded ? 'none' : `solid 1px ${COLORS.neutral['100']}`,
-        ':last-of-type': {
-          borderBottom: 'none',
+        ':not(:last-of-type)': {
+          borderBottom: shaded ? 'none' : `solid 1px ${COLORS.neutral['100']}`,
         },
         paddingTop: SPACING['XL'],
         paddingBottom: SPACING['XL'],
@@ -399,7 +398,7 @@ function TextPanel({ data }) {
               display: 'flex',
               marginBottom: SPACING['L'],
               paddingBottom: SPACING['M'],
-              borderBottom: `solid 1px ${COLORS.neutral['100']}`,
+              borderBottom: i !== items.length - 1 ? `solid 1px ${COLORS.neutral['100']}` : 'none',
             }}
           >
             <div


### PR DESCRIPTION
# Overview
Certain templates showed double borders between panels. Examples:
* [Janice Bluestein Longone Culinary Archive](https://www.lib.umich.edu/collections/collecting-areas/special-collections-and-archives/janice-bluestein-longone-culinary)
* [Funded Publications](https://lib.umich.edu/research-and-scholarship/awards-and-grants/tome-publishing-grant/funded-publications)

This pull request removes the border on the last listed panel and resolves [WEBSITE-11](https://mlit.atlassian.net/browse/WEBSITE-11).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge