### PR TITLE
[WEBSITE-36] Add "non-library location" display for Events + Exhibits page and card templates

### DIFF
--- a/src/graphql/eventCardFragment.js
+++ b/src/graphql/eventCardFragment.js
@@ -17,6 +17,10 @@ export const query = graphql`
       end_value
     }
     field_event_online
+    field_event_in_non_library_locat
+    field_non_library_location_addre {
+      organization
+    }
     relationships {
       field_event_type {
         name

--- a/src/graphql/eventFragment.js
+++ b/src/graphql/eventFragment.js
@@ -25,6 +25,15 @@ export const query = graphql`
       uri
       title
     }
+    field_event_in_non_library_locat
+    field_non_library_location_addre {
+      organization
+      locality
+      address_line1
+      address_line2
+      postal_code
+      administrative_area
+    }
     relationships {
       field_library_contact {
         field_user_display_name

--- a/src/templates/event.js
+++ b/src/templates/event.js
@@ -250,21 +250,21 @@ function EventMetadata({ data }) {
             <th scope="row">Where</th>
             <td
               css={{
-                'p + p': {
+                'p + p:not(.margin-top-none)': {
                   marginTop: SPACING['XS'],
                 },
               }}
             >
-              {where.map(({ label, href }, index) => {
+              {where.map(({ label, href, className }, index) => {
                 if (href) {
                   return (
-                    <p key={index}>
+                    <p key={index} className={className}>
                       <Link to={href}>{label}</Link>
                     </p>
                   );
                 }
 
-                return <p key={index}>{label}</p>;
+                return <p key={index} className={className}>{label}</p>;
               })}
             </td>
           </tr>

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -103,8 +103,11 @@ export function eventFormatWhere({ node, kind }, includeLink = false) {
     });
   }
 
+  let hasLocation = false;
+
   if (!!node.field_event_in_non_library_locat && !!node.field_non_library_location_addre) {
     if (node.field_non_library_location_addre.organization) {
+      hasLocation = true;
       where.push({
         label: node.field_non_library_location_addre.organization
       });
@@ -129,9 +132,14 @@ export function eventFormatWhere({ node, kind }, includeLink = false) {
   const room = node.relationships.field_event_room?.title;
 
   if (building) {
+    hasLocation = true;
     where.push({
       label: [room, building].join(', '),
     });
+  }
+
+  if (node.field_event_online && hasLocation) {
+    where[0].label = 'Hybrid';
   }
 
   return where;

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -103,6 +103,28 @@ export function eventFormatWhere({ node, kind }, includeLink = false) {
     });
   }
 
+  if (!!node.field_event_in_non_library_locat && !!node.field_non_library_location_addre) {
+    if (node.field_non_library_location_addre.organization) {
+      where.push({
+        label: node.field_non_library_location_addre.organization
+      });
+    }
+    if (kind !== 'brief') {
+      const stateZip = [
+        node.field_non_library_location_addre.administrative_area,
+        node.field_non_library_location_addre.postal_code
+      ].filter((field) => field).join(' ')
+      where.push({
+        label: [
+          node.field_non_library_location_addre.address_line1,
+          node.field_non_library_location_addre.locality,
+          stateZip
+        ].filter((field) => field).join(', '),
+        className: 'margin-top-none'
+      });
+    }
+  }
+
   const building = node.relationships.field_event_building?.title;
   const room = node.relationships.field_event_room?.title;
 


### PR DESCRIPTION
# Overview
`field_event_in_non_library_locat` and `field_non_library_location_addre` were originally [removed](https://github.com/mlibrary/lib.umich.edu/commit/60946956e4e21e8a3f7bce44b80e20637bd97c59) from the `graphQL` queries because they were never added to the front-end. This pull request adds the fields back and applies them to the front-end.