### PR TITLE
[WEBSITE-71] Homepage hero not using mobile image?

### DIFF
--- a/src/components/panels/hero-search-box.js
+++ b/src/components/panels/hero-search-box.js
@@ -179,28 +179,28 @@ function Caption({ data }) {
 
 function BackgroundSection({ data, children, ...rest }) {
   const { field_hero_images } = data.relationships;
-  const smallScreenImage = field_hero_images.find(
-    (node) => node.field_orientation === 'vertical'
-  ).relationships.field_media_image.localFile.childImageSharp.gatsbyImageData;
-  const largeScreenImage = field_hero_images.find(
-    (node) => node.field_orientation === 'horizontal'
-  ).relationships.field_media_image.localFile.childImageSharp.gatsbyImageData;
-  const sources = [
-    smallScreenImage,
-    {
-      ...largeScreenImage,
-      media: `(min-width: 720px)`,
-    },
-  ];
+  const screenImage = (orientation) => {
+    return field_hero_images
+      .find((node) => node.field_orientation === orientation)
+      .relationships
+      .field_media_image
+      .localFile
+      .childImageSharp
+      .gatsbyImageData
+      .images
+      .fallback
+      .src;
+  };
 
   return (
     <section
       css={{
         backgroundColor: COLORS.neutral['100'],
-        backgroundImage: `url('${sources[1].images.fallback.src}')`,
-        backgroundPosition: 'center',
+        backgroundImage: `url('${screenImage('vertical')}')`,
+        backgroundPosition: 'center top 33%',
         [MEDIAQUERIES['M']]: {
-          backgroundSize: 'cover',
+          backgroundImage: `url('${screenImage('horizontal')}')`,
+          backgroundPosition: 'center left 20%',
         },
         position: 'relative'
       }}

--- a/src/graphql/heroPanelFragment.js
+++ b/src/graphql/heroPanelFragment.js
@@ -28,7 +28,7 @@ export const query = graphql`
             localFile {
               childImageSharp {
                 gatsbyImageData(
-                  width: 960
+                  width: 1200
                   placeholder: NONE
                   layout: CONSTRAINED
                 )


### PR DESCRIPTION
# Overview
The Home's search box image did not show the `horizontal` and `vertical` images, so now there is support for both. The `graphql` support now maxes the image `width` out at `1200`. The [old background positions](https://github.com/mlibrary/lib.umich.edu/blob/5bff0b6b15c6fb70ed8a311408a433403a015960/src/components/panels/hero-search-box.js) have also been added back. 