### PR TITLE
Fixing component flickering on query parameter changes

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,3 +1,7 @@
-export const onRenderBody = ({ setHtmlAttributes }) => {
+export const onRenderBody = ({ setHtmlAttributes, setHeadComponents }) => {
   setHtmlAttributes({ lang: 'en' });
+  setHeadComponents([
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@umich-lib/css@1.0.9/dist/umich-lib.css" />,
+    <script async type="text/javascript" src="https://umich.edu/apis/umalerts/umalerts.js"></script>
+  ]);
 };

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -35,20 +35,29 @@ function SearchEngineOptimization({data, children, titleField}) {
     return siteData.site.siteMetadata.description;
   }
   const metaKeywords = () => {
-    return field_seo_keywords ? field_seo_keywords.split(', ') : [];
+    if (!field_seo_keywords) {
+      return null;
+    }
+    return (
+      <meta name="keywords" content={field_seo_keywords} />
+    );
   }
+  const siteTitle = () => {
+    if (!metaTitle() || metaTitle() === 'Home') {
+      return defaultTitle;
+    }
+    return `${metaTitle()} | ${defaultTitle}`;
+  };
   return (
     <>
-      <title>{metaTitle() && metaTitle() !== 'Home' ? metaTitle() + ' | ' : ''}{defaultTitle}</title>
+      <title>{siteTitle()}</title>
       <meta property="og:title" content={metaTitle() && metaTitle() !== 'Home' ? metaTitle() : defaultTitle} />
       <meta name="description" content={metaDescription()}/>
-      <meta name="keywords" content={metaKeywords()} />
+      {metaKeywords()}
       <meta property="og:description" content={metaDescription()} />
       <meta property="og:type" content="website" />
       <meta property="twitter:description" content={metaDescription()} />
       <link rel="canonical" href={siteData.site.siteMetadata.siteUrl} />
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@umich-lib/css@1.0.9/dist/umich-lib.css" />
-      <script async type="text/javascript" src="https://umich.edu/apis/umalerts/umalerts.js"></script>
       {children}
     </>
   );

--- a/src/reusable/window-resize.js
+++ b/src/reusable/window-resize.js
@@ -1,31 +1,31 @@
 import React from 'react';
 
 function canUseDOM() {
-	return !!(
-		typeof window !== 'undefined' &&
-		window.document &&
-		window.document.createElement
-	);
+  return !!(
+    typeof window !== 'undefined' &&
+    window.document &&
+    window.document.createElement
+  );  
 }
 
 const useIsomorphicLayoutEffect = canUseDOM()
-	? React.useLayoutEffect
-	: React.useEffect;
+  ? React.useLayoutEffect
+  : React.useEffect;
 
 export default function WindowResize() {
-	let { current: hasWindow } = React.useRef(canUseDOM());
-	const [dimensions, setDimensions] = React.useState({
-		width: hasWindow ? window.innerWidth : 0,
-		height: hasWindow ? window.innerHeight : 0,
-	});
-	useIsomorphicLayoutEffect(() => {
-		const resize = () =>
-			setDimensions({
-				width: window.innerWidth,
-				height: window.innerHeight,
-			});
-		window.addEventListener('resize', resize);
-		return () => window.removeEventListener('resize', resize);
-	}, []);
-	return dimensions.width;
+  let { current: hasWindow } = React.useRef(canUseDOM());
+  const [dimensions, setDimensions] = React.useState({
+    width: hasWindow ? window.innerWidth : 0,
+    height: hasWindow ? window.innerHeight : 0,
+  });
+  useIsomorphicLayoutEffect(() => {
+    const resize = () =>
+      setDimensions({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    window.addEventListener('resize', resize);
+    return () => window.removeEventListener('resize', resize);
+  }, []);
+  return dimensions.width;
 }


### PR DESCRIPTION
# Overview
When searching in the Staff Directory or Find a Specialist, deleting characters would cause Design System components to flicker as the query parameter updated. That is because the styles were being loaded in the Gatsby Head API, which updated every time the query updated. The styles and scripts have been moved to `gatsby-ssr` since they will never be dynamically updated.

## WindowResize
The `WindowResize` function has been update to match the [scripts](https://github.com/reach/reach-ui/blob/dev/packages/window-size/src/reach-window-size.tsx) originally provided by `@reach`.