### PR TITLE
Bug: Page not scrolling when searching via mobile

### DIFF
--- a/src/components/site-search.js
+++ b/src/components/site-search.js
@@ -264,6 +264,11 @@ function ResultsList({ searching, noResults, results, query, error }) {
                   },
                 },
               }}
+              onClick={() => {
+                if (document.body.classList.contains('stop-scroll')) {
+                  document.body.classList.remove('stop-scroll')
+                }
+              }}
             >
               <ResultContent query={query} result={result} />
             </GatsbyLink>


### PR DESCRIPTION
# Overview
When [replacing `@reach/dialog`](https://github.com/mlibrary/lib.umich.edu/commit/e87051e16edbedf8422fcdd97206e7177114e9f2), a `stop-scroll` class was added to the `body` to prevent scrolling when the `dialog` was `open`. However, when selecting a result and going to an internal page, the class did not get removed. This pull request makes sure the class gets removed when a result link is clicked.