### PR TITLE
[WEBSITE-85] Title and Title in Context search engine indexing messed up for Basic CT

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -20,11 +20,11 @@ function SearchEngineOptimization({data, children, titleField}) {
     if (titleField && data[titleField]) {
       return data[titleField];
     }
-    if (field_title_context) {
-      return field_title_context;
-    }
     if (title) {
       return title;
+    }
+    if (field_title_context) {
+      return field_title_context;
     }
     return null;
   }

--- a/src/templates/floor-plan.js
+++ b/src/templates/floor-plan.js
@@ -89,7 +89,7 @@ function FloorPlanTemplate({ data }) {
 export default FloorPlanTemplate;
 
 export function Head({ data }) {
-  return <SearchEngineOptimization data={data.floorPlan} titleField='title' />;
+  return <SearchEngineOptimization data={data.floorPlan} />;
 }
 
 export const query = graphql`

--- a/src/templates/news-landing.js
+++ b/src/templates/news-landing.js
@@ -125,7 +125,7 @@ export default function NewsLandingTemplate({ data }) {
 }
 
 export function Head({ data }) {
-  return <SearchEngineOptimization data={data.page} titleField='title' />;
+  return <SearchEngineOptimization data={data.page} />;
 }
 
 function processNewsData(data) {

--- a/src/templates/section.js
+++ b/src/templates/section.js
@@ -122,7 +122,7 @@ function SectionTemplate({ data, ...rest }) {
 export default SectionTemplate;
 
 export function Head({ data }) {
-  return <SearchEngineOptimization data={data.page} titleField='title' />;
+  return <SearchEngineOptimization data={data.page} />;
 }
 
 export const query = graphql`

--- a/src/templates/visit.js
+++ b/src/templates/visit.js
@@ -123,7 +123,7 @@ export default function VisitTemplate({ data, ...rest }) {
 }
 
 export function Head({ data }) {
-  return <SearchEngineOptimization data={getNode(data)} titleField='title' />;
+  return <SearchEngineOptimization data={getNode(data)} />;
 }
 
 function HTMLList({ data }) {


### PR DESCRIPTION
# Overview
In the `SearchEngineOptimization` component, if `titleField` was not defined, `field_title_context` was being used as the default. It has been switched to `title` to make clear what a page was about if you were coming from outside the site, and avoid unnecessary repetition when you’re on the website proper.