### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -65,7 +65,7 @@ jobs:
       # Enabling cache
       - name: Caching Gatsby
         id: gatsby-cache-build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             public

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # Get code from repo
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       # Get tag from action input
@@ -59,7 +59,7 @@ jobs:
           ref: ${{ github.event.inputs.tag }}
       # Install NodeJS
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
       # Enabling cache

--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Get code from repo
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       # Get tag from action input
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ github.event.inputs.tag }}
       # Install NodeJS
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
       # Run npm install and build on our code

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -65,7 +65,7 @@ jobs:
       # Enabling cache
       - name: Caching Gatsby
         id: gatsby-cache-build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             public

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # Get code from repo
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       # Get tag from action input
@@ -59,7 +59,7 @@ jobs:
           ref: ${{ github.event.inputs.tag }}
       # Install NodeJS
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
       # Enabling cache

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -33,7 +33,7 @@ jobs:
       # Enabling cache
       - name: Caching Gatsby
         id: gatsby-cache-build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             public

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       # Get code from repo
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       # Install NodeJS
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
       # Enabling cache


### PR DESCRIPTION
When running GitHub actions, there is a warning in Annotations:
```
build
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-node@v1, actions/cache@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```
The workflows are set up to install Node.js `18.x` (the latest stable version), but is not being recognized.

`cache`, `checkout`, and `setup-node` have all been upgraded to `v3`.