### PR TITLE
Updating `sitemap` value for `gatsby-plugin-robots-txt`.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,7 +33,7 @@ module.exports = {
       resolve: 'gatsby-plugin-robots-txt',
       options: {
         host: siteMetadata.siteUrl,
-        sitemap: siteMetadata.siteUrl + '/sitemap.xml',
+        sitemap: siteMetadata.siteUrl + '/sitemap-index.xml',
         resolveEnv: () => {
           /**
            *


### PR DESCRIPTION
# Overview
The [sitemap](https://www.lib.umich.edu/sitemap.xml) on [`robots.txt`](https://www.lib.umich.edu/robots.txt) throws a `404`. [`gatsby-plugin-robots-txt`](https://www.gatsbyjs.com/plugins/gatsby-plugin-robots-txt/) generates the site's `robots.txt` file, which was originally pointing to the sitemap: `https://www.lib.umich.edu/sitemap.xml`.

[`gatsby-plugin-sitemap`](https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/) generates the `.xml` files for the sitemap. For every 45000 URLs the site has, it generates a `sitemap-#.xml` file (`#` starting at `0`), along with a `sitemap-index.xml` file to point to the generated files. This means that the file `https://www.lib.umich.edu/sitemap.xml` never existed. The `sitemap` has been updated to point to the generated file.

## Testing
- Does the `sitemap` in `robots.txt` file now point to `https://www.lib.umich.edu/sitemap-index.xml`?