### PR TITLE
WEBSITE-102 Initial display of event time is inaccurate

### DIFF
--- a/src/components/event-card.js
+++ b/src/components/event-card.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+
 import {
   EXHIBIT_TYPES,
   eventFormatWhen,
-  eventFormatWhere,
+  eventFormatWhere
 } from '../utils/events';
 import { Heading, SPACING, COLORS, TYPOGRAPHY, Icon } from '../reusable';
 import CardImage from '../reusable/card-image';
@@ -10,7 +11,11 @@ import MEDIA_QUERIES from '../reusable/media-queries';
 import icons from '../reusable/icons';
 import Link from './link';
 
-export default function EventCard(node) {
+export default function EventCard (node) {
+  const [initialized, setInitialized] = useState(false);
+  useEffect(() => {
+    setInitialized(true);
+  }, []);
   const {
     displayImage = true,
     title,
@@ -18,7 +23,7 @@ export default function EventCard(node) {
     body,
     fields,
     field_event_date_s_,
-    hasBorder = true,
+    hasBorder = true
   } = node;
   const image =
     relationships.field_media_image &&
@@ -31,44 +36,52 @@ export default function EventCard(node) {
   const type = relationships.field_event_type.name;
   const isAnExhibit = EXHIBIT_TYPES.includes(type);
   const useBorder = hasBorder;
-  const when = eventFormatWhen({
-    start,
-    end,
-    kind: 'brief',
-    type,
-  });
-  const where = eventFormatWhere({
-    node,
-    kind: 'brief',
-  });
+  const when = initialized
+    ? eventFormatWhen({
+      start,
+      end,
+      kind: 'brief',
+      type
+    })
+    : null;
+  const where = initialized
+    ? eventFormatWhere({
+      node,
+      kind: 'brief'
+    })
+    : null;
   const to = fields.slug;
+
+  if (!initialized) {
+    return null;
+  }
 
   return (
     <section
       css={{
-        paddingBottom: SPACING['L'],
-        marginTop: SPACING['L'],
-        [MEDIA_QUERIES['L']]: {
+        paddingBottom: SPACING.L,
+        marginTop: SPACING.L,
+        [MEDIA_QUERIES.L]: {
           display: displayImage ? 'grid' : 'block',
-          gridTemplateColumns: `16rem 1fr `,
-          gridGap: SPACING['M'],
+          gridTemplateColumns: '16rem 1fr ',
+          gridGap: SPACING.M
         },
-        borderBottom: useBorder ? `solid 1px ${COLORS.neutral['100']}` : '',
+        borderBottom: useBorder ? `solid 1px ${COLORS.neutral['100']}` : ''
       }}
     >
       {displayImage && <CardImage image={imageData} />}
       <div>
         <Heading
-          size="S"
+          size='S'
           level={2}
           css={{
             display: 'flex',
             flexDirection: 'column',
-            marginBottom: SPACING['2XS'],
+            marginBottom: SPACING['2XS']
           }}
         >
           <span css={{ order: 1 }}>
-            <Link to={to} kind="description">
+            <Link to={to} kind='description'>
               {title}
             </Link>
           </span>
@@ -78,7 +91,7 @@ export default function EventCard(node) {
               display: 'block',
               color: COLORS.neutral['300'],
               order: 0,
-              ...TYPOGRAPHY['3XS'],
+              ...TYPOGRAPHY['3XS']
             }}
           >
             {when}
@@ -87,7 +100,7 @@ export default function EventCard(node) {
         <p
           css={{
             marginTop: SPACING['2XS'],
-            color: COLORS.neutral['300'],
+            color: COLORS.neutral['300']
           }}
         >
           {body.summary}
@@ -95,38 +108,40 @@ export default function EventCard(node) {
 
         <p
           css={{
-            marginTop: SPACING['2XS'],
+            marginTop: SPACING['2XS']
           }}
         >
           <span
             css={{
               color: COLORS.neutral['300'],
-              marginRight: SPACING['L'],
+              marginRight: SPACING.L
             }}
           >
-            <Icon d={icons['address']} />
+            <Icon d={icons.address} />
             <span
               css={{
-                marginLeft: SPACING['XS'],
+                marginLeft: SPACING.XS
               }}
             >
-              <span className="visually-hidden">Where: </span>
-              {where.map((item) => item.label).join('; ')}
+              <span className='visually-hidden'>Where: </span>
+              {where.map((item) => {
+                return item.label;
+              }).join('; ')}
             </span>
           </span>
           {!isAnExhibit && (
             <span
               css={{
-                color: COLORS.neutral['300'],
+                color: COLORS.neutral['300']
               }}
             >
-              <Icon d="M21.41 11.58l-9-9C12.05 2.22 11.55 2 11 2H4c-1.1 0-2 .9-2 2v7c0 .55.22 1.05.59 1.42l9 9c.36.36.86.58 1.41.58.55 0 1.05-.22 1.41-.59l7-7c.37-.36.59-.86.59-1.41 0-.55-.23-1.06-.59-1.42zM5.5 7C4.67 7 4 6.33 4 5.5S4.67 4 5.5 4 7 4.67 7 5.5 6.33 7 5.5 7z" />
+              <Icon d='M21.41 11.58l-9-9C12.05 2.22 11.55 2 11 2H4c-1.1 0-2 .9-2 2v7c0 .55.22 1.05.59 1.42l9 9c.36.36.86.58 1.41.58.55 0 1.05-.22 1.41-.59l7-7c.37-.36.59-.86.59-1.41 0-.55-.23-1.06-.59-1.42zM5.5 7C4.67 7 4 6.33 4 5.5S4.67 4 5.5 4 7 4.67 7 5.5 6.33 7 5.5 7z' />
               <span
                 css={{
-                  marginLeft: SPACING['XS'],
+                  marginLeft: SPACING.XS
                 }}
               >
-                <span className="visually-hidden">Event type: </span>
+                <span className='visually-hidden'>Event type: </span>
                 {type}
               </span>
             </span>

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
 import { COLORS, SPACING, Margins, Heading, MEDIA_QUERIES } from '../reusable';
 
 import fdlp from '../images/fdlp.png';
@@ -9,7 +10,7 @@ import createGoogleMapsUrl from './utilities/create-google-maps-url';
 
 const locationURL = createGoogleMapsUrl({
   query:
-    'University of Michigan Library, 913 S. University Avenue, Ann Arbor, MI 48109',
+    'University of Michigan Library, 913 S. University Avenue, Ann Arbor, MI 48109'
 });
 
 // eslint-disable-next-line
@@ -19,36 +20,36 @@ const links = [
     links: [
       {
         text: (
-          <React.Fragment>
+          <>
             913 S. University Avenue
             <br />
             Ann Arbor, MI 48109-1190
-          </React.Fragment>
+          </>
         ),
         to: locationURL,
-        d: icons['address'],
+        d: icons.address
       },
       {
         text: '(734) 764-0400',
         to: 'tel:+1-734-764-0400',
-        d: icons['phone'],
+        d: icons.phone
       },
       {
         text: 'Send us an email',
         to: 'https://umich.qualtrics.com/jfe/form/SV_2bpfeZMnAK2ozhr',
-        icon: 'mail_outline',
+        icon: 'mail_outline'
       },
       {
         text: 'Accessibility',
         to: '/about-us/about-library/diversity-equity-inclusion-and-accessibility/accessibility',
-        icon: 'accessible_forward',
+        icon: 'accessible_forward'
       },
       {
         text: 'Site map',
         to: '/site-map',
-        icon: 'map',
-      },
-    ],
+        icon: 'map'
+      }
+    ]
   },
   {
     heading: 'Our community',
@@ -56,149 +57,155 @@ const links = [
       {
         text: 'Staff directory',
         to: '/about-us/staff-directory',
-        icon: 'people_outline',
+        icon: 'people_outline'
       },
       {
         text: 'Work for us',
         to: '/about-us/work-us',
-        icon: 'work',
+        icon: 'work'
       },
       {
         text: 'Blogs',
         to: 'https://apps.lib.umich.edu/blogs',
-        icon: 'blog',
+        icon: 'blog'
       },
       {
         text: 'Facebook',
         to: 'https://www.facebook.com/pages/University-of-Michigan-Library/110483979013559',
-        icon: 'facebook',
+        icon: 'facebook'
       },
       {
         text: 'Twitter',
         to: 'https://twitter.com/umichlibrary',
-        icon: 'twitter',
+        icon: 'twitter'
       },
       {
         text: 'YouTube',
         to: 'http://www.youtube.com/user/umlibrary/videos',
-        icon: 'youtube',
-      },
-    ],
-  },
+        icon: 'youtube'
+      }
+    ]
+  }
 ];
 
-function Footer() {
-  const now = new Date();
-  const year = now.getFullYear();
+function Footer () {
+  const [year, setYear] = useState(null);
+
+  useEffect(() => {
+    const now = new Date();
+    setYear(now.getFullYear());
+  }, [year]);
 
   return (
     <footer
       css={{
-        background: COLORS['blue']['400'],
+        background: COLORS.blue['400'],
         '*:focus': {
-          outlineColor: 'white',
-        },
+          outlineColor: 'white'
+        }
       }}
     >
       <Margins
         css={{
-          color: 'white',
+          color: 'white'
         }}
       >
         <div
           css={{
             paddingTop: SPACING['2XL'],
-            paddingBottom: SPACING['L'],
+            paddingBottom: SPACING.L,
             [MEDIA_QUERIES.LARGESCREEN]: {
               paddingTop: SPACING['3XL'],
               columns: '3',
-              columnGap: SPACING['XL'],
+              columnGap: SPACING.XL,
               '& section': {
                 breakInside: 'avoid',
-                marginBottom: '0',
-              },
+                marginBottom: '0'
+              }
             },
             '& section:not(:last-of-type)': {
-              marginBottom: SPACING['XL'],
+              marginBottom: SPACING.XL
             },
             'a:hover': {
-              textDecoration: 'underline',
+              textDecoration: 'underline'
             },
             'h2, h3': {
-              color: COLORS['blue']['200'],
-            },
+              color: COLORS.blue['200']
+            }
           }}
         >
-          {links.map((section) => (
-            <section key={section.heading}>
-              <Heading level={2} size="3XS">
-                {section.heading}
-              </Heading>
-              <ul
-                css={{
-                  paddingTop: SPACING['S'],
-                }}
-              >
-                {section.links.map(({ text, to, d, icon }, y) => {
-                  return (
-                    <li key={y + to + text}>
-                      <PlainLink
-                        to={to}
-                        css={{
-                          display: 'inline-block',
-                          padding: `${SPACING['XS']} 0`,
-                        }}
-                      >
-                        <IconText icon={icon} d={d}>
-                          {text}
-                        </IconText>
-                      </PlainLink>
-                    </li>
-                  );
-                })}
-              </ul>
-            </section>
-          ))}
+          {links.map((section) => {
+            return (
+              <section key={section.heading}>
+                <Heading level={2} size='3XS'>
+                  {section.heading}
+                </Heading>
+                <ul
+                  css={{
+                    paddingTop: SPACING.S
+                  }}
+                >
+                  {section.links.map(({ text, to, d, icon }, y) => {
+                    return (
+                      <li key={y + to + text}>
+                        <PlainLink
+                          to={to}
+                          css={{
+                            display: 'inline-block',
+                            padding: `${SPACING.XS} 0`
+                          }}
+                        >
+                          <IconText icon={icon} d={d}>
+                            {text}
+                          </IconText>
+                        </PlainLink>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            );
+          })}
           <section
             css={{
               a: {
-                textDecoration: 'underline',
+                textDecoration: 'underline'
               },
               borderTop: `solid 1px ${COLORS.blue['200']}`,
-              paddingTop: SPACING['XL'],
+              paddingTop: SPACING.XL,
               [MEDIA_QUERIES.LARGESCREEN]: {
                 border: '0',
                 padding: '0',
                 borderLeft: `solid 1px ${COLORS.blue['300']}`,
-                paddingLeft: SPACING['XL'],
-                marginLeft: `-${SPACING['2XL']}`,
-              },
+                paddingLeft: SPACING.XL,
+                marginLeft: `-${SPACING['2XL']}`
+              }
             }}
           >
             <Heading
               level={2}
-              size="3XS"
+              size='3XS'
               css={{
-                paddingBottom: SPACING['S'],
+                paddingBottom: SPACING.S
               }}
             >
               Privacy and copyright
             </Heading>
-            <PlainLink to="/about-us/policies/library-privacy-statement">
+            <PlainLink to='/about-us/policies/library-privacy-statement'>
               Library Privacy Statement
             </PlainLink>
             <p
               css={{
-                paddingTop: SPACING['S'],
-                paddingBottom: SPACING['L'],
+                paddingTop: SPACING.S,
+                paddingBottom: SPACING.L
               }}
             >
               Except where otherwise noted, this work is subject to a{' '}
-              <a href="http://creativecommons.org/licenses/by/4.0/">
+              <a href='http://creativecommons.org/licenses/by/4.0/'>
                 Creative Commons Attribution 4.0 license
               </a>
               . For details and exceptions, see the{' '}
-              <PlainLink to="/about-us/policies/copyright-policy">
+              <PlainLink to='/about-us/policies/copyright-policy'>
                 Library Copyright Policy
               </PlainLink>
               .
@@ -206,13 +213,13 @@ function Footer() {
 
             <p
               css={{
-                display: 'flex',
+                display: 'flex'
               }}
             >
               <img
                 src={fdlp}
-                alt=""
-                css={{ height: '2rem', marginRight: SPACING['S'] }}
+                alt=''
+                css={{ height: '2rem', marginRight: SPACING.S }}
               />
               <span>Federal Depository Library Program</span>
             </p>
@@ -221,14 +228,14 @@ function Footer() {
 
         <p
           css={{
-            marginBottom: SPACING['2XL'],
+            marginBottom: SPACING['2XL']
           }}
         >
           Have a question about this website?{' '}
           <a
-            href="https://umich.qualtrics.com/jfe/form/SV_87ZJbL09VT6wZvL"
+            href='https://umich.qualtrics.com/jfe/form/SV_87ZJbL09VT6wZvL'
             css={{
-              textDecoration: 'underline',
+              textDecoration: 'underline'
             }}
           >
             Contact the website team
@@ -238,21 +245,21 @@ function Footer() {
       </Margins>
       <div
         css={{
-          background: COLORS['blue']['500'],
-          padding: `${SPACING['M']} 0`,
-          color: COLORS.blue['200'],
+          background: COLORS.blue['500'],
+          padding: `${SPACING.M} 0`,
+          color: COLORS.blue['200']
         }}
       >
         <Margins>
           <span
             css={{
-              marginRight: SPACING['XL'],
+              marginRight: SPACING.XL,
               display: 'block',
-              paddingBottom: SPACING['XS'],
+              paddingBottom: SPACING.XS,
               [MEDIA_QUERIES.LARGESCREEN]: {
                 display: 'inline',
-                padding: '0',
-              },
+                padding: '0'
+              }
             }}
           >
             © {year}, Regents of the University of Michigan
@@ -260,12 +267,12 @@ function Footer() {
 
           <span
             css={{
-              marginRight: SPACING['XL'],
+              marginRight: SPACING.XL
             }}
           >
             Built with the{' '}
             <a
-              href="https://design-system.lib.umich.edu/"
+              href='https://design-system.lib.umich.edu/'
               css={{ textDecoration: 'underline' }}
             >
               U-M Library Design System
@@ -275,7 +282,7 @@ function Footer() {
           <span>
             <PlainLink
               css={{ textDecoration: 'underline' }}
-              to="/release-notes"
+              to='/release-notes'
             >
               Release notes
             </PlainLink>

--- a/src/components/panels/featured-and-latest-news.js
+++ b/src/components/panels/featured-and-latest-news.js
@@ -5,28 +5,25 @@ import { SPACING, MEDIA_QUERIES, COLORS, Heading, Margins } from '../../reusable
 import Card from '../card';
 import Link from '../link';
 
-function processNewsNodeForCard ({ newsNode }, initialized) {
-  if (initialized) {
-    const newsImage =
+function processNewsNodeForCard ({ newsNode }) {
+  const newsImage =
     newsNode.relationships?.field_media_image?.relationships?.field_media_image
       ?.localFile?.childImageSharp?.gatsbyImageData;
 
-    const children = newsNode.body?.summary;
+  const children = newsNode.body?.summary;
 
-    return {
-      title: newsNode.title,
-      subtitle: new Date(newsNode.created).toLocaleString('en-US', {
-        timeZone: 'America/New_York',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric'
-      }),
-      href: newsNode.fields.slug,
-      image: newsImage,
-      children
-    };
-  }
-  return null;
+  return {
+    title: newsNode.title,
+    subtitle: new Date(newsNode.created).toLocaleString('en-US', {
+      timeZone: 'America/New_York',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    }),
+    href: newsNode.fields.slug,
+    image: newsImage,
+    children
+  };
 }
 
 /*
@@ -46,6 +43,14 @@ const Layout = styled.div({
 
 export default function FeaturedAndLatestNews () {
   const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    setInitialized(true);
+  }, [initialized]);
+
+  if (!initialized) {
+    return <>…</>;
+  }
 
   const data = useStaticQuery(graphql`
     query {
@@ -110,16 +115,12 @@ export default function FeaturedAndLatestNews () {
   }
 
   const featureNode = data.featuredNews.edges[0].node;
-  const featureCardProps = processNewsNodeForCard({ newsNode: featureNode }, initialized);
+  const featureCardProps = processNewsNodeForCard({ newsNode: featureNode });
   const recentNews = sortNews({ data });
   const recentNewsCardProps = recentNews.map(({ node }) => {
-    return processNewsNodeForCard({ newsNode: node }, initialized);
+    return processNewsNodeForCard({ newsNode: node });
   });
   const viewAllNewsHref = data.newsLandingPage.fields.slug;
-
-  useEffect(() => {
-    setInitialized(true);
-  }, []);
 
   if (!featureCardProps || featureCardProps.length === 0 || !recentNewsCardProps || recentNewsCardProps.length === 0) {
     return null;

--- a/src/components/panels/featured-and-latest-news.js
+++ b/src/components/panels/featured-and-latest-news.js
@@ -16,6 +16,7 @@ function processNewsNodeForCard ({ newsNode }, initialized) {
     return {
       title: newsNode.title,
       subtitle: new Date(newsNode.created).toLocaleString('en-US', {
+        timeZone: 'America/New_York',
         year: 'numeric',
         month: 'long',
         day: 'numeric'

--- a/src/components/panels/featured-and-latest-news.js
+++ b/src/components/panels/featured-and-latest-news.js
@@ -1,28 +1,31 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useStaticQuery, graphql } from 'gatsby';
 import styled from '@emotion/styled';
 import { SPACING, MEDIA_QUERIES, COLORS, Heading, Margins } from '../../reusable';
 import Card from '../card';
 import Link from '../link';
 
-function processNewsNodeForCard ({ newsNode }) {
-  const newsImage =
+function processNewsNodeForCard ({ newsNode }, initialized) {
+  if (initialized) {
+    const newsImage =
     newsNode.relationships?.field_media_image?.relationships?.field_media_image
       ?.localFile?.childImageSharp?.gatsbyImageData;
 
-  const children = newsNode.body?.summary;
+    const children = newsNode.body?.summary;
 
-  return {
-    title: newsNode.title,
-    subtitle: new Date(newsNode.created).toLocaleString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    }),
-    href: newsNode.fields.slug,
-    image: newsImage,
-    children
-  };
+    return {
+      title: newsNode.title,
+      subtitle: new Date(newsNode.created).toLocaleString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+      }),
+      href: newsNode.fields.slug,
+      image: newsImage,
+      children
+    };
+  }
+  return null;
 }
 
 /*
@@ -41,6 +44,8 @@ const Layout = styled.div({
 });
 
 export default function FeaturedAndLatestNews () {
+  const [initialized, setInitialized] = useState(false);
+
   const data = useStaticQuery(graphql`
     query {
       featuredNews: allNodeNews(
@@ -104,12 +109,20 @@ export default function FeaturedAndLatestNews () {
   }
 
   const featureNode = data.featuredNews.edges[0].node;
-  const featureCardProps = processNewsNodeForCard({ newsNode: featureNode });
+  const featureCardProps = processNewsNodeForCard({ newsNode: featureNode }, initialized);
   const recentNews = sortNews({ data });
   const recentNewsCardProps = recentNews.map(({ node }) => {
-    return processNewsNodeForCard({ newsNode: node });
+    return processNewsNodeForCard({ newsNode: node }, initialized);
   });
   const viewAllNewsHref = data.newsLandingPage.fields.slug;
+
+  useEffect(() => {
+    setInitialized(true);
+  }, []);
+
+  if (!featureCardProps || featureCardProps.length === 0 || !recentNewsCardProps || recentNewsCardProps.length === 0) {
+    return null;
+  }
 
   return (
     <Margins>

--- a/src/components/panels/hours-lite-panel.js
+++ b/src/components/panels/hours-lite-panel.js
@@ -10,12 +10,17 @@ import PropTypes from 'prop-types';
 
 export default function HoursLitePanel ({ data }) {
   const [initialized, setInitialized] = useState(false);
-  const { field_title: fieldTitle } = data;
-  const hours = processHoursData(data.relationships.field_cards, initialized);
 
   useEffect(() => {
     setInitialized(true);
-  }, []);
+  }, [initialized]);
+
+  if (!initialized) {
+    return <>…</>;
+  }
+
+  const { field_title: fieldTitle } = data;
+  const hours = processHoursData(data.relationships.field_cards);
 
   return (
     <section>
@@ -138,12 +143,8 @@ const hoursDataExample = [
 
 function processHoursData (data, initialized) {
   function hours (node) {
-    if (initialized) {
-      const now = new Date();
-      return displayHours({ node, now });
-    }
-
-    return { text: '...', label: 'Loading hours... ' };
+    const now = new Date();
+    return displayHours({ node, now });
   }
 
   const result = data.map((node) => {

--- a/src/components/panels/hours-panel.js
+++ b/src/components/panels/hours-panel.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Margins,
   Heading,
@@ -14,7 +14,7 @@ import { useStateValue } from '../use-state';
 import { displayHours } from '../../utils/hours';
 import PropTypes from 'prop-types';
 
-const dateFormat = (string, abbreviated = false) => {
+const dateFormat = (string, abbreviated = false, initialized) => {
   if (abbreviated) {
     return string.toLocaleString('en-US', {
       timeZone: 'America/New_York',
@@ -32,6 +32,12 @@ const dateFormat = (string, abbreviated = false) => {
 };
 
 export function HoursPanelNextPrev ({ location }) {
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    setInitialized(true);
+  }, []);
+
   const [{ weekOffset }, dispatch] = useStateValue();
   const date = new Date();
 
@@ -42,10 +48,12 @@ export function HoursPanelNextPrev ({ location }) {
   toDate.setDate(date.getDate() + (weekOffset * 7) + (6 - date.getDay()));
 
   const hoursRange = {
-    text: `${dateFormat(fromDate, true)} - ${dateFormat(toDate, true)}`,
-    label: `Showing hours for ${location} from ${dateFormat(fromDate)} to ${dateFormat(toDate)}`
+    text: `${dateFormat(fromDate, true, initialized)} - ${dateFormat(toDate, true, initialized)}`,
+    label: `Showing hours for ${location} from ${dateFormat(fromDate, false, initialized)} to ${dateFormat(toDate, false, initialized)}`
   };
-
+  if (!initialized) {
+    return null;
+  }
   return (
     <Margins data-hours-panel-next-previous>
       <div
@@ -171,6 +179,12 @@ PreviousNextWeekButton.propTypes = {
 };
 
 export default function HoursPanelContainer ({ data }) {
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    setInitialized(true);
+  }, []);
+
   const [{ weekOffset }] = useStateValue();
   const { relationships, field_body: fieldBody } = data;
 
@@ -179,6 +193,10 @@ export default function HoursPanelContainer ({ data }) {
   }
 
   const { title } = relationships.field_parent_card[0];
+
+  if (!initialized) {
+    return null;
+  }
 
   return (
     <section
@@ -205,7 +223,7 @@ export default function HoursPanelContainer ({ data }) {
           data={transformTableData({
             node: data,
             now: new Date(new Date().setDate(new Date().getDate() + weekOffset * 7))
-          })}
+          }, initialized)}
           dayOfWeek={weekOffset === 0 ? new Date().getDay() : false}
           location={title}
         />
@@ -218,7 +236,7 @@ HoursPanelContainer.propTypes = {
   data: PropTypes.object
 };
 
-function transformTableData ({ node, now }) {
+function transformTableData ({ node, now }, initialized) {
   const { field_cards: fieldCards, field_parent_card: fieldParentCard } = node.relationships;
 
   /*

--- a/src/components/panels/hours-panel.js
+++ b/src/components/panels/hours-panel.js
@@ -32,13 +32,16 @@ const dateFormat = (string, abbreviated = false, initialized) => {
 };
 
 export function HoursPanelNextPrev ({ location }) {
+  const [{ weekOffset }, dispatch] = useStateValue();
   const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
     setInitialized(true);
-  }, []);
+  }, [initialized]);
 
-  const [{ weekOffset }, dispatch] = useStateValue();
+  if (!initialized) {
+    return <>…</>;
+  }
   const date = new Date();
 
   const fromDate = new Date(date);
@@ -179,14 +182,18 @@ PreviousNextWeekButton.propTypes = {
 };
 
 export default function HoursPanelContainer ({ data }) {
+  const [{ weekOffset }] = useStateValue();
+  const { relationships, field_body: fieldBody } = data;
+
   const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
     setInitialized(true);
-  }, []);
+  }, [initialized]);
 
-  const [{ weekOffset }] = useStateValue();
-  const { relationships, field_body: fieldBody } = data;
+  if (!initialized) {
+    return <>…</>;
+  }
 
   if (relationships.field_parent_card.length === 0) {
     return null;

--- a/src/components/panels/hours-panel.js
+++ b/src/components/panels/hours-panel.js
@@ -17,11 +17,13 @@ import PropTypes from 'prop-types';
 const dateFormat = (string, abbreviated = false) => {
   if (abbreviated) {
     return string.toLocaleString('en-US', {
+      timeZone: 'America/New_York',
       month: 'short',
       day: 'numeric'
     });
   }
   return string.toLocaleString('en-US', {
+    timeZone: 'America/New_York',
     weekday: 'long',
     month: 'long',
     day: 'numeric',
@@ -248,10 +250,12 @@ function transformTableData ({ node, now }) {
     headings.push({
       text: daysOfWeek[date.getDay()],
       subtext: date.toLocaleString('en-US', {
+        timeZone: 'America/New_York',
         month: 'short',
         day: 'numeric'
       }),
       label: date.toLocaleString('en-US', {
+        timeZone: 'America/New_York',
         weekday: 'long',
         month: 'long',
         day: 'numeric'

--- a/src/templates/event.js
+++ b/src/templates/event.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { graphql } from 'gatsby';
 import { GatsbyImage } from 'gatsby-plugin-image';
 import { Margins, Heading, SPACING, COLORS, TYPOGRAPHY } from '../reusable';
@@ -13,6 +13,12 @@ import { eventFormatWhen, eventFormatWhere } from '../utils/events';
 import PropTypes from 'prop-types';
 
 function EventTemplate ({ data }) {
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    setInitialized(true);
+  }, []);
+
   const node = data.event;
   const { field_title_context: fieldTitleContext, body, fields, relationships } = node;
   const { slug } = fields;
@@ -25,6 +31,10 @@ function EventTemplate ({ data }) {
     relationships?.field_media_image?.field_image_caption?.processed;
   const contact = relationships?.field_library_contact;
   const eventContacts = relationships?.field_non_library_event_contact;
+
+  if (!initialized) {
+    return null;
+  }
 
   return (
     <TemplateLayout node={node}>

--- a/src/templates/news-landing.js
+++ b/src/templates/news-landing.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { graphql } from 'gatsby';
 import { Margins, Heading, SPACING, Expandable, ExpandableChildren, ExpandableButton } from '../reusable';
 import Layout from '../components/layout';
@@ -10,13 +10,22 @@ import { Template, TemplateSide, TemplateContent } from '../components/aside-lay
 import PropTypes from 'prop-types';
 
 function NewsLandingTemplate ({ data }) {
-  const news = processNewsData(data.featuredNews).concat(
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    setInitialized(true);
+  }, []);
+  const news = processNewsData(data.featuredNews, initialized).concat(
     processNewsData(data.restNews)
   );
-  const newsLibraryUpdates = processNewsData(data.newsLibraryUpdates);
+  const newsLibraryUpdates = processNewsData(data.newsLibraryUpdates, initialized);
   const newsMainInitialShow = 10;
   const newsLibraryUpdatesInitialShow = 20;
   const { field_title_context: fieldTitleContext, body, fields, drupal_internal__nid: drupalInternalNID } = data.page;
+
+  if (!initialized) {
+    return null;
+  }
 
   return (
     <Layout drupalNid={drupalInternalNID}>

--- a/src/templates/news-landing.js
+++ b/src/templates/news-landing.js
@@ -151,6 +151,7 @@ function processNewsData (data) {
       relationships?.field_media_image?.relationships?.field_media_image
         ?.localFile?.childImageSharp?.gatsbyImageData;
     const subtitle = new Date(created).toLocaleString('en-US', {
+      timeZone: 'America/New_York',
       year: 'numeric',
       month: 'long',
       day: 'numeric'

--- a/src/templates/news.js
+++ b/src/templates/news.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import SearchEngineOptimization from '../components/seo';
 import { graphql } from 'gatsby';
 import { GatsbyImage } from 'gatsby-plugin-image';
@@ -15,6 +15,11 @@ import Share from '../components/share';
 import PropTypes from 'prop-types';
 
 function NewsTemplate ({ data }) {
+  const [initialized, setInitialized] = useState(false);
+  useEffect(() => {
+    setInitialized(true);
+  }, []);
+
   const node = getNode(data);
   const { bodyPanels, fullPanels } = transformNodePanels({ node });
   const { field_title_context: fieldTitleContext, body, fields, relationships, created } = node;
@@ -31,6 +36,10 @@ function NewsTemplate ({ data }) {
     relationships.field_media_image.field_image_caption
       ? relationships.field_media_image.field_image_caption.processed
       : null;
+
+  if (!initialized) {
+    return null;
+  }
 
   return (
     <TemplateLayout node={node}>

--- a/src/templates/news.js
+++ b/src/templates/news.js
@@ -58,6 +58,7 @@ function NewsTemplate ({ data }) {
                 }}
               >
                 {new Date(created).toLocaleDateString('en-us', {
+                  timeZone: 'America/New_York',
                   year: 'numeric',
                   month: 'long',
                   day: 'numeric'

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -35,6 +35,7 @@ export const EXHIBIT_TYPES = ['Exhibit', 'Exhibition'];
 */
 const dateFormat = (date, ...properties) => {
   const options = {
+    timeZone: 'America/New_York',
     month: 'long',
     day: 'numeric'
   };
@@ -44,7 +45,10 @@ const dateFormat = (date, ...properties) => {
 };
 
 const timeFormat = (date) => {
-  return date.toLocaleTimeString('en-US', { timeStyle: 'short' });
+  return date.toLocaleTimeString('en-US', {
+    timeZone: 'America/New_York',
+    timeStyle: 'short'
+  });
 };
 
 export function eventFormatWhen ({ start, end, kind, type }) {


### PR DESCRIPTION
# Overview
It was brought to our attention that the time of an event was inaccurate when the page first loaded. After a brief moment, the page would appear to refresh / redirect and the time would be fixed.

At first I thought this was an issue with redirects. The pages are redirecting to exclude trailing slashes around the same time the page refreshes.

I later determined that the issue was due to a hydration error. The console was giving us vague errors but we determined that the `Date` object and `locale` references were causing the problems.

In short, the page would render with SSR and output the server locale time. Since the client page did not match the server page the page would rebuild on the client.

This fix does two things:
1. It makes sure all `locale` references include the `timeZone` option and is set to `America/New_York`. This will ensure the time will display properly regardless of the client's location.
2. It wraps all components that use the `Date` object in a `useEffect()` hook. This will ensure the client is rendering the component and not the server.

For the most part, I use a simplified useEffect() hook: 
```
const [initialized, setInitialized] = useState(false);
const [initialized, setInitialized] = useState(false);
  useEffect(() => {
    setInitialized(true);
  }, []);
```

Then I use the initialized state to determine the render output
```
if (!initialized) {
    return null;
}
```

> This pull request fixes [WEBSITE-102](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-102).

## Testing
This update impacts all locations where date and time are used.
Examples:
[Clark Commons Celebration (event details)](https://future-wwwlib-previews.netlify.app/visit-and-study/events-and-exhibits/today-and-upcoming/clark-commons-celebration)
[Homepage](https://future-wwwlib-previews.netlify.app/)
[Hours view](https://future-wwwlib-previews.netlify.app/locations-and-hours/hours-view)
[Locations and Hours](https://future-wwwlib-previews.netlify.app/locations-and-hours)
[Today and Upcoming (events summary)](https://future-wwwlib-previews.netlify.app/visit-and-study/events-and-exhibits/today-and-upcoming)

- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [x] Edge (the assignee was not able to test the pull request in this browser)
- Run accessibility / screen reader tests:
  - [x] WAVE
  - [x] NVDA
  - [ ] ARC Toolkit
  - [ ] axe DevTools
