### PR TITLE
Update events-and-exhibits-panel.js

### DIFF
--- a/src/components/panels/events-and-exhibits-panel.js
+++ b/src/components/panels/events-and-exhibits-panel.js
@@ -73,16 +73,15 @@ export default function EventsAndExhibitsPanel () {
       // Get Today's events.
       const todaysEvents = events.filter((event) => {
         const start = new Date(event.field_event_date_s_[0].value);
+        const end = new Date(event.field_event_date_s_[0].end_value);
         const type = event.relationships.field_event_type.name;
-
         // We don't want exhibits in the events area.
         if (EXHIBIT_TYPES.includes(type)) {
           return false;
         }
 
-        return new Date(now.toDateString()) === new Date(start.toDateString()); // all today.
+        return (now.toDateString() === new Date(start).toDateString()) && (now.toTimeString() < end.toTimeString()); // all today that haven't ended.
       });
-
       setTodaysEvents(todaysEvents);
     }
 


### PR DESCRIPTION
# Overview
Events in the "Todays Events" area on the [Today and Upcoming](https://lib.umich.edu/visit-and-study/events-and-exhibits/today-and-upcoming) page were not appearing. It looks like comparing date objects for equality doesn't do what I expected. Converting `toDateString()` fixes this. I also added a check to remove events where the end time is in the past.

> This pull request resolves/closes/fixes [WEBSITE-108](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-108).

## Testing
List instructions on how to test the pull request. Some examples:

- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [x] Edge (the assignee was not able to test the pull request in this browser)
