### PR TITLE
Fixing GitHub Action Annotation Warning

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -52,7 +52,7 @@ jobs:
       - run: npm run build
       # Deploy to s3
       - name: Set s3 bucket credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -62,7 +62,7 @@ jobs:
       # Notify Slack if build fails
       - name: Send custom JSON data to Slack workflow
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |
             {

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -30,16 +30,16 @@ jobs:
     steps:
       # Get code from repo
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Install NodeJS
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       # Enabling cache
       - name: Caching Gatsby
         id: gatsby-cache-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             public

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -21,21 +21,21 @@ jobs:
     steps:
       # Get code from repo
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: get short sha
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
           echo "DEPLOY_URL=https://deploy-preview-$SHORT_SHA--future-wwwlib-development.netlify.app" >> $GITHUB_ENV
       # Install NodeJS
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       # Enabling cache
       - name: Caching Gatsby
         id: gatsby-cache-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             public

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -57,7 +57,7 @@ jobs:
       # Notify Slack if build fails
       - name: Send custom JSON data to Slack workflow
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |
             {

--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo "DEPLOY_URL=https://deploy-preview-${{ github.event.number }}--future-wwwlib-previews.netlify.app" >> $GITHUB_ENV
       - name: Output summary
         run: echo $DEPLOY_URL >> $GITHUB_STEP_SUMMARY
-      - uses: LouisBrunner/checks-action@v1.6.1
+      - uses: LouisBrunner/checks-action@v2.0.0
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
       ## Notify Slack if build fails
       - name: Send custom JSON data to Slack workflow
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |
             {

--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -21,12 +21,12 @@ jobs:
     steps:
       # Get code from repo
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Install NodeJS
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       # Run npm install and build on our code
       - run: npm install
       - run: npm run build

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # Get code from repo
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       # Get tag from action input
@@ -58,14 +58,14 @@ jobs:
         with:
           ref: ${{ env.tag }}
       # Install NodeJS
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       # Enabling cache
       - name: Caching Gatsby
         id: gatsby-cache-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             public

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -54,7 +54,7 @@ jobs:
       # Checkout tag from repo
       - name: Checkout correct repository
         if: ${{ github.event_name == 'workflow_dispatch'  && github.events.inputs.tag }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.tag }}
       # Install NodeJS
@@ -87,7 +87,7 @@ jobs:
       # Notify Slack if build fails
       - name: Send custom JSON data to Slack workflow
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |
             {

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -55,7 +55,7 @@ jobs:
       # Notify Slack if build fails
       - name: Send custom JSON data to Slack workflow
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |
             {

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -24,16 +24,16 @@ jobs:
     steps:
       # Get code from repo
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Install NodeJS
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       # Enabling cache
       - name: Caching Gatsby
         id: gatsby-cache-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             public


### PR DESCRIPTION
We are getting annotation warnings on our GitHub Actions notifying us of Node.js 16 deprecation for GitHub actions: 

`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, actions/cache@v3.`

[More information is available on the GitHub blog](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

Updated node to v20 from v18, now using setup-node@v4, checkout@v4, and cache@v4.

This addresses [Website-113 Update GitHub actions to use latest Node version](https://mlit.atlassian.net/browse/WEBSITE-113?focusedCommentId=360500&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-360500)
