### PR TITLE
Update events-and-exhibits-panel.js

### DIFF
--- a/src/components/panels/events-and-exhibits-panel.js
+++ b/src/components/panels/events-and-exhibits-panel.js
@@ -92,7 +92,6 @@ export default function EventsAndExhibitsPanel () {
       // useEffects are only client side, so we can use now here.
 
       // Get upcoming events.
-      // This is repetative... but :shrug:
       const upcomingEvents = events.filter((event) => {
         const start = new Date(event.field_event_date_s_[0].value);
         const type = event.relationships.field_event_type.name;
@@ -101,7 +100,7 @@ export default function EventsAndExhibitsPanel () {
         if (EXHIBIT_TYPES.includes(type)) {
           return false;
         }
-        return now < start; // all after today.
+        return now < new Date(start.toDateString()); // all after today.
       });
 
       setUpcomingEvents(upcomingEvents);


### PR DESCRIPTION
# Overview
There's a bug on the Today and Upcoming events page. The Upcoming Events area also includes today's events. Today's events have a dedicated section so all of today's events are duplicated.

Upcoming events was comparing two date strings with time, so if the event start time is in the future it would return the item. Converting the event's `start` date object to a new date with `.toDateString()` will effectively set the start time to 00:00:00 so `now` will always be after today's events.

> This pull request fixes [WEBSITE-117](https://mlit.atlassian.net/browse/WEBSITE-117).

[Netlify Preview](https://deploy-preview-280--future-wwwlib-previews.netlify.app/)

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari (the assignee was not able to test the pull request in this browser)
  - [x] Edge 
- Run accessibility tests:
  - [x] ARC Toolkit
  - [x] Screen reader testing (NVDA)
