### PR TITLE
Removed old links

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -219,23 +219,6 @@ function Footer () {
             </p>
           </section>
         </div>
-
-        <p
-          css={{
-            marginBottom: SPACING['2XL']
-          }}
-        >
-          Have a question about this website?{' '}
-          <a
-            href='https://umich.qualtrics.com/jfe/form/SV_87ZJbL09VT6wZvL'
-            css={{
-              textDecoration: 'underline'
-            }}
-          >
-            Contact the website team
-          </a>
-          .
-        </p>
       </Margins>
       <div
         css={{
@@ -271,15 +254,6 @@ function Footer () {
             >
               U-M Library Design System
             </a>
-          </span>
-
-          <span>
-            <PlainLink
-              css={{ textDecoration: 'underline' }}
-              to='/release-notes'
-            >
-              Release notes
-            </PlainLink>
           </span>
         </Margins>
       </div>


### PR DESCRIPTION
# Overview
This update is removing two links in the footer area:
- "Have a question about this website? Contact the website team."
- "Release notes" (dark blue footer)

> This pull request resolves/closes/fixes [WEBSITE-119](https://mlit.atlassian.net/browse/WEBSITE-119).

## Testing
The two links are in the footer on all pages. The [live site](https://lib.umich.edu/) could be used as reference for where the links were.

- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari (the developer was not able to test the pull request in this browser)
  - [x] Edge 
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [ ] axe DevTools
