### PR TITLE
Update index.js

### DIFF
--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -204,7 +204,6 @@ function CardPanel ({ data, headingLevel = 2 }) {
                 marginTop: SPACING.XL,
                 ':first-of-type': {
                   marginTop: 0,
-                  color: 'red'
                 },
                 [MEDIA_QUERIES.LARGESCREEN]: {
                   margin: '0'

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -5,7 +5,7 @@ import {
   COLORS,
   Margins,
   Icon,
-  MEDIA_QUERIES,
+  MEDIA_QUERIES
 } from '../../reusable';
 
 import Card from '../card';
@@ -27,7 +27,7 @@ import Image from '../image';
 
 import { StateProvider } from '../use-state';
 
-function PanelTemplate({ title, children, shaded, ...rest }) {
+function PanelTemplate ({ title, children, shaded, ...rest }) {
   return (
     <section
       data-can-be-shaded={shaded}
@@ -36,13 +36,14 @@ function PanelTemplate({ title, children, shaded, ...rest }) {
         background: shaded ? COLORS.blue['100'] : '',
         ':not(:last-of-type)': {
           borderBottom: shaded ? 'none' : `solid 1px ${COLORS.neutral['100']}`,
+          paddingBottom: SPACING['3XL']
         },
-        paddingTop: SPACING['XL'],
-        paddingBottom: SPACING['XL'],
+        paddingTop: SPACING.XL,
+        paddingBottom: SPACING.XL,
         [MEDIA_QUERIES.LARGESCREEN]: {
           paddingTop: SPACING['3XL'],
-          paddingBottom: SPACING['3XL'],
-        },
+          paddingBottom: SPACING['3XL']
+        }
       }}
       {...rest}
     >
@@ -50,9 +51,9 @@ function PanelTemplate({ title, children, shaded, ...rest }) {
         {title && (
           <Heading
             level={2}
-            size="M"
+            size='M'
             css={{
-              marginBottom: SPACING['XL'],
+              marginBottom: SPACING.XL
             }}
           >
             {title}
@@ -64,14 +65,13 @@ function PanelTemplate({ title, children, shaded, ...rest }) {
   );
 }
 
-function PanelList({ largeScreenTwoColumn, children, twoColumns, ...rest }) {
+function PanelList ({ largeScreenTwoColumn, children, twoColumns, ...rest }) {
   const panelListGridStyles = {
     [MEDIA_QUERIES.LARGESCREEN]: {
-      marginBottom: SPACING['XL'],
       display: 'grid',
       gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
-      gridGap: `${SPACING['XL']} ${SPACING['M']}`,
-    },
+      gridGap: `${SPACING.XL} ${SPACING.M}`
+    }
   };
   const panelListColumnStyles = {
     [MEDIA_QUERIES.LARGESCREEN]: {
@@ -79,9 +79,9 @@ function PanelList({ largeScreenTwoColumn, children, twoColumns, ...rest }) {
       columnGap: SPACING['3XL'],
       '> li': {
         breakInside: 'avoid',
-        marginBottom: SPACING['XL'],
-      },
-    },
+        marginBottom: SPACING.XL
+      }
+    }
   };
 
   return (
@@ -94,7 +94,7 @@ function PanelList({ largeScreenTwoColumn, children, twoColumns, ...rest }) {
   );
 }
 
-function CardPanel({ data, headingLevel = 2 }) {
+function CardPanel ({ data, headingLevel = 2 }) {
   const template = data.relationships.field_card_template.field_machine_name;
 
   if (template === 'destination_hor_card_template') {
@@ -106,7 +106,7 @@ function CardPanel({ data, headingLevel = 2 }) {
   const noImage = template === 'standard_no_image';
   const useSummary = template !== 'address_and_hours';
 
-  function getCardSubtitle(card) {
+  function getCardSubtitle (card) {
     if (template === 'destination_card_template') {
       return getParentTitle({ node: card });
     }
@@ -114,14 +114,14 @@ function CardPanel({ data, headingLevel = 2 }) {
     return null;
   }
 
-  function getImage(image) {
+  function getImage (image) {
     return !image || noImage
       ? null
       : image.relationships.field_media_image.localFile.childImageSharp
-          .gatsbyImageData;
+        .gatsbyImageData;
   }
 
-  function getCardHref(card) {
+  function getCardHref (card) {
     if (card.field_url) {
       return card.field_url.uri;
     }
@@ -129,47 +129,47 @@ function CardPanel({ data, headingLevel = 2 }) {
     return card.fields.slug;
   }
 
-  function getSummary(body) {
+  function getSummary (body) {
     return body ? body.summary : null;
   }
 
-  function renderCardChildren(data) {
+  function renderCardChildren (data) {
     if (template === 'address_and_hours') {
       return (
-        <React.Fragment>
+        <>
           <div
             css={{
               display: 'flex',
-              marginTop: SPACING['XS'],
+              marginTop: SPACING.XS
             }}
           >
             <span
               css={{
                 color: COLORS.maize['500'],
-                marginRight: SPACING['XS'],
+                marginRight: SPACING.XS
               }}
             >
-              <Icon d={icons['address']} />
+              <Icon d={icons.address} />
             </span>
             <Address node={data} />
           </div>
           <div
             css={{
               display: 'flex',
-              marginTop: SPACING['XS'],
+              marginTop: SPACING.XS
             }}
           >
             <span
               css={{
                 color: COLORS.maize['500'],
-                marginRight: SPACING['XS'],
+                marginRight: SPACING.XS
               }}
             >
-              <Icon d={icons['clock']} />
+              <Icon d={icons.clock} />
             </span>
             <Hours node={data} />
           </div>
-        </React.Fragment>
+        </>
       );
     }
 
@@ -179,40 +179,42 @@ function CardPanel({ data, headingLevel = 2 }) {
   return (
     <PanelTemplate title={title}>
       <PanelList twoColumns={noImage}>
-        {cards.map((card, i) => (
-          <li
-            key={i + card.title}
-            css={{
-              marginBottom: SPACING['XL'],
-              [MEDIA_QUERIES.LARGESCREEN]: {
-                margin: '0',
-              },
-            }}
-          >
-            <Card
-              image={
+        {cards.map((card, i) => {
+          return (
+            <li
+              key={i + card.title}
+              css={{
+                marginBottom: SPACING.XL,
+                [MEDIA_QUERIES.LARGESCREEN]: {
+                  margin: '0'
+                }
+              }}
+            >
+              <Card
+                image={
                 card.relationships
                   ? getImage(card.relationships.field_media_image)
                   : null
               }
-              href={getCardHref(card)}
-              subtitle={getCardSubtitle(card)}
-              title={card.title}
-              children={
+                href={getCardHref(card)}
+                subtitle={getCardSubtitle(card)}
+                title={card.title}
+                children={
                 useSummary ? getSummary(card.body) : renderCardChildren(card)
               }
-              css={{
-                height: '100%',
-              }}
-            />
-          </li>
-        ))}
+                css={{
+                  height: '100%'
+                }}
+              />
+            </li>
+          );
+        })}
       </PanelList>
     </PanelTemplate>
   );
 }
 
-function MarginsWrapper({ useMargins = false, children }) {
+function MarginsWrapper ({ useMargins = false, children }) {
   if (useMargins) {
     return <Margins>{children}</Margins>;
   }
@@ -220,7 +222,7 @@ function MarginsWrapper({ useMargins = false, children }) {
   return children;
 }
 
-function TextPanel({ data }) {
+function TextPanel ({ data }) {
   const title = data.field_title;
   const placement = data.field_placement;
   const template = data.relationships.field_text_template.field_machine_name;
@@ -230,16 +232,16 @@ function TextPanel({ data }) {
     return (
       <MarginsWrapper useMargins={placement !== 'body'}>
         <Callout
-          intent="warning"
+          intent='warning'
           css={{
-            maxWidth: placement === 'body' ? '38rem' : '100%',
+            maxWidth: placement === 'body' ? '38rem' : '100%'
           }}
         >
           <Heading
             level={2}
-            size="M"
+            size='M'
             css={{
-              marginBottom: SPACING['XS'],
+              marginBottom: SPACING.XS
             }}
           >
             {title}
@@ -249,8 +251,8 @@ function TextPanel({ data }) {
             html={cards[0].field_body.processed}
             css={{
               '> *': {
-                maxWidth: placement === 'body' ? '38rem' : '100%',
-              },
+                maxWidth: placement === 'body' ? '38rem' : '100%'
+              }
             }}
           />
         </Callout>
@@ -267,31 +269,33 @@ function TextPanel({ data }) {
       <MarginsWrapper useMargins={useMargins}>
         <div
           css={{
-            marginTop: hasMarginTop ? SPACING['XL'] : 0,
+            marginTop: hasMarginTop ? SPACING.XL : 0
           }}
         >
-          {cards.map((card, index) => (
-            <section
-              key={`section-${index}`}
-              css={{
-                paddingTop: hasTopBorder ? SPACING['XL'] : 0,
-                borderTop: hasTopBorder
-                  ? `solid 1px ${COLORS.neutral['100']}`
-                  : 'none',
-              }}
-            >
-              <Heading
-                level={2}
-                size="M"
+          {cards.map((card, index) => {
+            return (
+              <section
+                key={`section-${index}`}
                 css={{
-                  marginBottom: SPACING['L'],
+                  paddingTop: hasTopBorder ? SPACING.XL : 0,
+                  borderTop: hasTopBorder
+                    ? `solid 1px ${COLORS.neutral['100']}`
+                    : 'none'
                 }}
               >
-                {title}
-              </Heading>
-              <Html html={card.field_body.processed} />
-            </section>
-          ))}
+                <Heading
+                  level={2}
+                  size='M'
+                  css={{
+                    marginBottom: SPACING.L
+                  }}
+                >
+                  {title}
+                </Heading>
+                <Html html={card.field_body.processed} />
+              </section>
+            );
+          })}
         </div>
       </MarginsWrapper>
     );
@@ -308,27 +312,27 @@ function TextPanel({ data }) {
           paddingBottom: SPACING['3XL'],
           [MEDIA_QUERIES.LARGESCREEN]: {
             paddingTop: SPACING['4XL'],
-            paddingBottom: SPACING['4XL'],
-          },
+            paddingBottom: SPACING['4XL']
+          }
         }}
       >
         <div
           css={{
             display: 'flex',
-            justifyContent: 'center',
+            justifyContent: 'center'
           }}
         >
           <div
             css={{
               textAlign: 'center',
-              maxWidth: '38rem',
+              maxWidth: '38rem'
             }}
           >
             <Heading
               level={2}
-              size="M"
+              size='M'
               css={{
-                marginBottom: SPACING['M'],
+                marginBottom: SPACING.M
               }}
             >
               {title}
@@ -345,31 +349,33 @@ function TextPanel({ data }) {
   if (template === 'grid_text_template_with_linked_title') {
     return (
       <PanelTemplate title={title}>
-        <PanelList twoColumns={true}>
-          {cards.map(({ field_title, field_body, field_link }, i) => (
-            <li
-              key={i + field_title}
-              css={{
-                marginBottom: SPACING['XL'],
-                [MEDIA_QUERIES.LARGESCREEN]: {
-                  margin: '0',
-                },
-              }}
-            >
-              <div
+        <PanelList twoColumns>
+          {cards.map(({ field_title, field_body, field_link }, i) => {
+            return (
+              <li
+                key={i + field_title}
                 css={{
-                  marginBottom: SPACING['XS'],
+                  marginBottom: SPACING.XL,
+                  [MEDIA_QUERIES.LARGESCREEN]: {
+                    margin: '0'
+                  }
                 }}
               >
-                <Link to={field_link[0].uri} kind="description">
-                  {field_title}
-                </Link>
-              </div>
-              <div css={{ color: COLORS.neutral['300'] }}>
-                <Html html={field_body.processed} />
-              </div>
-            </li>
-          ))}
+                <div
+                  css={{
+                    marginBottom: SPACING.XS
+                  }}
+                >
+                  <Link to={field_link[0].uri} kind='description'>
+                    {field_title}
+                  </Link>
+                </div>
+                <div css={{ color: COLORS.neutral['300'] }}>
+                  <Html html={field_body.processed} />
+                </div>
+              </li>
+            );
+          })}
         </PanelList>
       </PanelTemplate>
     );
@@ -385,49 +391,51 @@ function TextPanel({ data }) {
             .localFile.childImageSharp.gatsbyImageData,
         imageAlt:
           card.relationships.field_text_image.relationships.field_media_image
-            .relationships?.media__image[0]?.field_media_image.alt,
+            .relationships?.media__image[0]?.field_media_image.alt
       };
     });
 
     return (
       <PanelTemplate title={title}>
-        {items.map(({ heading, html, image, imageAlt }, i) => (
-          <section
-            key={i + html}
-            css={{
-              display: 'flex',
-              marginBottom: SPACING['L'],
-              paddingBottom: SPACING['M'],
-              borderBottom: i !== items.length - 1 ? `solid 1px ${COLORS.neutral['100']}` : 'none',
-            }}
-          >
-            <div
+        {items.map(({ heading, html, image, imageAlt }, i) => {
+          return (
+            <section
+              key={i + html}
               css={{
-                width: '8rem',
-                marginRight: SPACING['L'],
-                flexShrink: '0',
+                display: 'flex',
+                marginBottom: SPACING.L,
+                paddingBottom: SPACING.M,
+                borderBottom: i !== items.length - 1 ? `solid 1px ${COLORS.neutral['100']}` : 'none'
               }}
             >
-              <Image image={image} alt={imageAlt} />
-            </div>
-            <div>
-              {heading && (
-                <Heading
-                  level={title ? 2 : 2} // Use heading level 3 if has (h2) panel title.
-                  size="S"
-                  css={{
-                    marginTop: `0 !important`,
-                    marginBottom: SPACING['XS'],
-                  }}
-                >
-                  {heading}
-                </Heading>
-              )}
+              <div
+                css={{
+                  width: '8rem',
+                  marginRight: SPACING.L,
+                  flexShrink: '0'
+                }}
+              >
+                <Image image={image} alt={imageAlt} />
+              </div>
+              <div>
+                {heading && (
+                  <Heading
+                    level={title ? 2 : 2} // Use heading level 3 if has (h2) panel title.
+                    size='S'
+                    css={{
+                      marginTop: '0 !important',
+                      marginBottom: SPACING.XS
+                    }}
+                  >
+                    {heading}
+                  </Heading>
+                )}
 
-              <Html html={html} />
-            </div>
-          </section>
-        ))}
+                <Html html={html} />
+              </div>
+            </section>
+          );
+        })}
       </PanelTemplate>
     );
   }
@@ -435,7 +443,7 @@ function TextPanel({ data }) {
   return null;
 }
 
-export default function Panels({ data }) {
+export default function Panels ({ data }) {
   if (!data) {
     return null;
   }
@@ -472,9 +480,9 @@ export default function Panels({ data }) {
   );
 }
 
-function PanelStateWrapper({ children }) {
+function PanelStateWrapper ({ children }) {
   const initialState = {
-    weekOffset: 0,
+    weekOffset: 0
   };
 
   const reducer = (state, action) => {
@@ -482,7 +490,7 @@ function PanelStateWrapper({ children }) {
       case 'setWeekOffset':
         return {
           ...state,
-          weekOffset: action.weekOffset,
+          weekOffset: action.weekOffset
         };
       default:
         return state;

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -24,6 +24,7 @@ import getParentTitle from '../../utils/get-parent-title';
 import CustomPanel from './custom-panel';
 import Callout from '../../reusable/callout';
 import Image from '../image';
+import PropTypes from 'prop-types';
 
 import { StateProvider } from '../use-state';
 
@@ -65,6 +66,12 @@ function PanelTemplate ({ title, children, shaded, ...rest }) {
   );
 }
 
+PanelTemplate.propTypes = {
+  title: PropTypes.string,
+  children: PropTypes.any,
+  shaded: PropTypes.bool
+};
+
 function PanelList ({ largeScreenTwoColumn, children, twoColumns, ...rest }) {
   const panelListGridStyles = {
     [MEDIA_QUERIES.LARGESCREEN]: {
@@ -97,6 +104,12 @@ function PanelList ({ largeScreenTwoColumn, children, twoColumns, ...rest }) {
     </ol>
   );
 }
+
+PanelList.propTypes = {
+  largeScreenTwoColumn: PropTypes.any,
+  children: PropTypes.any,
+  twoColumns: PropTypes.bool
+};
 
 function CardPanel ({ data, headingLevel = 2 }) {
   const template = data.relationships.field_card_template.field_machine_name;
@@ -207,13 +220,12 @@ function CardPanel ({ data, headingLevel = 2 }) {
                 href={getCardHref(card)}
                 subtitle={getCardSubtitle(card)}
                 title={card.title}
-                children={
-                useSummary ? getSummary(card.body) : renderCardChildren(card)
-              }
                 css={{
                   height: '100%'
                 }}
-              />
+              >
+                {useSummary ? getSummary(card.body) : renderCardChildren(card)}
+              </Card>
             </li>
           );
         })}
@@ -222,6 +234,11 @@ function CardPanel ({ data, headingLevel = 2 }) {
   );
 }
 
+CardPanel.propTypes = {
+  data: PropTypes.any,
+  headingLevel: PropTypes.number
+};
+
 function MarginsWrapper ({ useMargins = false, children }) {
   if (useMargins) {
     return <Margins>{children}</Margins>;
@@ -229,6 +246,11 @@ function MarginsWrapper ({ useMargins = false, children }) {
 
   return children;
 }
+
+MarginsWrapper.propTypes = {
+  useMargins: PropTypes.bool,
+  children: PropTypes.any
+};
 
 function TextPanel ({ data }) {
   const title = data.field_title;
@@ -358,10 +380,10 @@ function TextPanel ({ data }) {
     return (
       <PanelTemplate title={title}>
         <PanelList twoColumns>
-          {cards.map(({ field_title, field_body, field_link }, i) => {
+          {cards.map(({ field_title: fieldTitle, field_body: fieldBody, field_link: fieldLink }, i) => {
             return (
               <li
-                key={i + field_title}
+                key={i + fieldTitle}
                 css={{
                   marginBottom: SPACING.XL,
                   [MEDIA_QUERIES.LARGESCREEN]: {
@@ -374,12 +396,12 @@ function TextPanel ({ data }) {
                     marginBottom: SPACING.XS
                   }}
                 >
-                  <Link to={field_link[0].uri} kind='description'>
-                    {field_title}
+                  <Link to={fieldLink[0].uri} kind='description'>
+                    {fieldTitle}
                   </Link>
                 </div>
                 <div css={{ color: COLORS.neutral['300'] }}>
-                  <Html html={field_body.processed} />
+                  <Html html={fieldBody.processed} />
                 </div>
               </li>
             );
@@ -451,6 +473,10 @@ function TextPanel ({ data }) {
   return null;
 }
 
+TextPanel.propTypes = {
+  data: PropTypes.object
+};
+
 export default function Panels ({ data }) {
   if (!data) {
     return null;
@@ -488,6 +514,10 @@ export default function Panels ({ data }) {
   );
 }
 
+Panels.propTypes = {
+  data: PropTypes.object
+};
+
 function PanelStateWrapper ({ children }) {
   const initialState = {
     weekOffset: 0
@@ -511,5 +541,9 @@ function PanelStateWrapper ({ children }) {
     </StateProvider>
   );
 }
+
+PanelStateWrapper.propTypes = {
+  children: PropTypes.any
+};
 
 export { PanelTemplate, PanelList };

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -76,14 +76,15 @@ function PanelList ({ largeScreenTwoColumn, children, twoColumns, ...rest }) {
   const panelListColumnStyles = {
     [MEDIA_QUERIES.LARGESCREEN]: {
       columns: '2',
-      columnGap: SPACING['3XL'],
-      '> li': {
-        marginTop: SPACING.XL,
-        breakInside: 'avoid'
-      },
-      '> li:first-of-type': {
-        marginTop: 0
-      }
+      columnGap: SPACING['3XL']
+    },
+    '> li': {
+      marginTop: SPACING.XL,
+      marginBottom: 0,
+      breakInside: 'avoid'
+    },
+    '> li:first-of-type': {
+      marginTop: 0
     }
   };
 
@@ -187,7 +188,11 @@ function CardPanel ({ data, headingLevel = 2 }) {
             <li
               key={i + card.title}
               css={{
-                marginBottom: SPACING.XL,
+                marginTop: SPACING.XL,
+                ':first-of-type': {
+                  marginTop: 0,
+                  color: 'red'
+                },
                 [MEDIA_QUERIES.LARGESCREEN]: {
                   margin: '0'
                 }

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -78,8 +78,11 @@ function PanelList ({ largeScreenTwoColumn, children, twoColumns, ...rest }) {
       columns: '2',
       columnGap: SPACING['3XL'],
       '> li': {
-        breakInside: 'avoid',
-        marginBottom: SPACING.XL
+        marginTop: SPACING.XL,
+        breakInside: 'avoid'
+      },
+      '> li:first-of-type': {
+        marginTop: 0
       }
     }
   };


### PR DESCRIPTION
# Overview
This fix should address inconsistent behavior with padding around the bottom border that’s built into a specific Text Panel template. 

There are additional screenshots of the issue in the JIRA Ticket:
> This pull request fixes [WEBSITE-122](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-122).

**Before updates, here are published lib pages for reference:**
- [Other Libraries and Collections](https://lib.umich.edu/locations-and-hours/other-libraries-and-collections) entirely built with text panel type in full width placement and looks as expected.
- [Copyright Services](https://lib.umich.edu/research-and-scholarship/copyright-services) uses this panel for “Use guides” and the rest are card panels. All in full width placement and looks as expected.
- [Copyright Guides](https://lib.umich.edu/research-and-scholarship/copyright-services/guides) has 4 of this type of text panel in body width placement. The first one doesn’t have any padding between the last item and the bottom border, but the rest look fine. The whole page looks perfect on small screens.
- [Sustainability Resources](https://lib.umich.edu/about-us/news/sustainability-resources) is a news item, so it has body on the left and the sidebar on the right. It uses 3 of this type of panel and there’s a little bit of padding for the first and none for the second. Again, looks great on small screen.

**After updates, here is the preview build with the same pages from above along with a few more pages I used for reference**
- [Other Libraries and Collections](https://deploy-preview-289--future-wwwlib-previews.netlify.app/locations-and-hours/other-libraries-and-collections)
- [Copyright Services](https://deploy-preview-289--future-wwwlib-previews.netlify.app/research-and-scholarship/copyright-services)
- [Copyright Guides](https://deploy-preview-289--future-wwwlib-previews.netlify.app/research-and-scholarship/copyright-services/guides)
- [Sustainability Resources](https://deploy-preview-289--future-wwwlib-previews.netlify.app/about-us/news/sustainability-resources)
- [News Landing Page](https://deploy-preview-288--future-wwwlib-previews.netlify.app/about-us/news)
- [Cafes](https://deploy-preview-289--future-wwwlib-previews.netlify.app/visit-and-study/cafes-and-wellbeing/cafes)
- [Information Desks](https://deploy-preview-289--future-wwwlib-previews.netlify.app/visit-and-study/information-desks)
- [Screen Arts Mavericks and Makers](https://deploy-preview-289--future-wwwlib-previews.netlify.app/collections/collecting-areas/special-collections-and-archives/screen-arts-mavericks-and-makers)
- [Taubman Heath Sciences Library](https://deploy-preview-289--future-wwwlib-previews.netlify.app/locations-and-hours/taubman-health-sciences-library)
- [Clark Library](https://deploy-preview-289--future-wwwlib-previews.netlify.app/locations-and-hours/clark-library)
- [Asia Library](https://deploy-preview-289--future-wwwlib-previews.netlify.app/locations-and-hours/asia-library)

## Testing
List instructions on how to test the pull request. Some examples:

- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] ARC Toolkit
