### PR TITLE
Website 99 icon color contrast

### DIFF
--- a/src/components/location-aside.js
+++ b/src/components/location-aside.js
@@ -105,7 +105,7 @@ export default function LocationAside ({ node }) {
           <Address node={node} directions={true} kind='full' />
         </LayoutWithIcon>
 
-        <LayoutWithIcon d={icons.phone} palette='maize'>
+        <LayoutWithIcon d={icons.phone} palette='neutral'>
           <Heading
             level={2}
             size='M'

--- a/src/components/location-aside.js
+++ b/src/components/location-aside.js
@@ -105,7 +105,7 @@ export default function LocationAside ({ node }) {
           <Address node={node} directions={true} kind='full' />
         </LayoutWithIcon>
 
-        <LayoutWithIcon d={icons.phone} palette='neutral'>
+        <LayoutWithIcon d={icons.phone} palette='green'>
           <Heading
             level={2}
             size='M'

--- a/src/components/panels/hours-lite-panel.js
+++ b/src/components/panels/hours-lite-panel.js
@@ -66,7 +66,7 @@ export default function HoursLitePanel ({ data }) {
             >
               <span
                 css={{
-                  color: hour.isOpen ? COLORS.neutral['300'] : COLORS.pink['300'],
+                  color: COLORS.neutral['300'],
                   display: 'inline',
                   flexShrink: '0',
                   width: '1.5rem'

--- a/src/components/panels/hours-lite-panel.js
+++ b/src/components/panels/hours-lite-panel.js
@@ -66,7 +66,7 @@ export default function HoursLitePanel ({ data }) {
             >
               <span
                 css={{
-                  color: COLORS.neutral['300'],
+                  color: COLORS.indigo['300'],
                   display: 'inline',
                   flexShrink: '0',
                   width: '1.5rem'

--- a/src/components/panels/hours-lite-panel.js
+++ b/src/components/panels/hours-lite-panel.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 const processHoursData = (data, initialized) => {
   const hours = (node) => {
     if (initialized) {
-      const now = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
+      const now = new Date(new Date().toLocaleString('en-US', { timeZone: 'UTC' }));
       return displayHours({ node, now });
     }
 
@@ -25,6 +25,7 @@ const processHoursData = (data, initialized) => {
     };
 
     return {
+      isOpen: hoursData.isOpen,
       subLabel: `TODAY: ${label}`,
       subText: `TODAY: ${text}`,
       text: node.title,
@@ -65,7 +66,7 @@ export default function HoursLitePanel ({ data }) {
             >
               <span
                 css={{
-                  color: COLORS.maize['500'],
+                  color: hour.isOpen ? COLORS.neutral['300'] : COLORS.pink['300'],
                   display: 'inline',
                   flexShrink: '0',
                   width: '1.5rem'

--- a/src/components/panels/hours-lite-panel.js
+++ b/src/components/panels/hours-lite-panel.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 const processHoursData = (data, initialized) => {
   const hours = (node) => {
     if (initialized) {
-      const now = new Date(new Date().toLocaleString('en-US', { timeZone: 'UTC' }));
+      const now = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/New_York' }));
       return displayHours({ node, now });
     }
 

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -161,7 +161,7 @@ const CardPanel = ({ data }) => {
           >
             <span
               css={{
-                color: COLORS.maize['500'],
+                color: COLORS.indigo['300'],
                 marginRight: SPACING.XS
               }}
             >
@@ -177,7 +177,7 @@ const CardPanel = ({ data }) => {
           >
             <span
               css={{
-                color: COLORS.maize['500'],
+                color: COLORS.indigo['300'],
                 marginRight: SPACING.XS
               }}
             >

--- a/src/components/todays-hours.js
+++ b/src/components/todays-hours.js
@@ -23,7 +23,6 @@ export default function Hours ({ node }) {
   if (!hours) {
     return 'Today: n/a';
   }
-
   return <span aria-label={hours.label}>Today: {hours.text}</span>;
 }
 

--- a/src/utils/hours.js
+++ b/src/utils/hours.js
@@ -144,6 +144,8 @@ export const displayHours = ({ node, now }) => {
     return null;
   }
 
+  let isOpen = true;
+
   const hoursForNow = hoursSet.field_hours_open.find(
     (data) => {
       return data.day === now.getDay();
@@ -195,9 +197,16 @@ export const displayHours = ({ node, now }) => {
 
     text = combinedValues('-');
     label = combinedValues();
+
+    // Convert starthours and endhours to Date objects for comparison
+    const closingTime = new Date(now);
+    closingTime.setHours(Math.floor(endhours / 100), endhours % 100, 0, 0);
+
+    isOpen = now < closingTime;
   }
 
   return {
+    isOpen,
     label,
     text
   };

--- a/src/utils/hours.js
+++ b/src/utils/hours.js
@@ -144,8 +144,6 @@ export const displayHours = ({ node, now }) => {
     return null;
   }
 
-  let isOpen = true;
-
   const hoursForNow = hoursSet.field_hours_open.find(
     (data) => {
       return data.day === now.getDay();
@@ -197,16 +195,9 @@ export const displayHours = ({ node, now }) => {
 
     text = combinedValues('-');
     label = combinedValues();
-
-    // Convert starthours and endhours to Date objects for comparison
-    const closingTime = new Date(now);
-    closingTime.setHours(Math.floor(endhours / 100), endhours % 100, 0, 0);
-
-    isOpen = now < closingTime;
   }
 
   return {
-    isOpen,
     label,
     text
   };


### PR DESCRIPTION
# Overview
This PR addresses issues with color contrast and is the first of many PRs addressing the issues outlined in the [baseline accessibility evaluation](https://docs.google.com/document/d/1PGCPqSdbGEgx83_zMgkJvoCHYd3dhtQleoZBwPAgKzQ/edit#heading=h.8tfnur19cudx). 

I put together a [comprehensive document outlining all the locations we are using icons on the site](https://docs.google.com/document/d/1HPsjTD-6lRQvwMHvaeeyuerCtj93pI_3JsX-cPmkhm4/edit). Of all the locations we are using icons, there are two that do not meet the 3:1 contrast ratio. At the time of creating these icons, it was determined that they were supportive icons so 3:1 color contrast was not necessary. However, to ensure our products are accessible and to continue to strive for excellent, user-friendly experiences, we can make these icons a slightly different color.

The four areas where icons do not meet the 3:1 color contrast ratio are:

1. The "Plan your visit" hours-lite-panel on the [homepage](https://lib.umich.edu/).
2. The location-aside panel on the [location details page](https://lib.umich.edu/locations-and-hours/hatcher-library)
3. Address and time icon on [locations and hours page](https://lib.umich.edu/locations-and-hours)
4. Callout (see the bottom of [the locations and hours page](https://lib.umich.edu/locations-and-hours))

The callout at the bottom of the page will later be replaced with the design-system callout (WIP). No changes to the callout in this PR.

The colors on the homepage icons are now using the `COLORS.indigo['300']` This will later be replaced with the design system's `var(--color-indigo-300)`.

> This pull request resolves [WEBSITE-99](https://mlit.atlassian.net/browse/WEBSITE-99).

## Testing
Check the following deploy URL for the three updated color icons:
https://deploy-preview-299--future-wwwlib-previews.netlify.app/

The specific pages where you can find the color changes are:

- [Locations and Hours](https://deploy-preview-299--future-wwwlib-previews.netlify.app/locations-and-hours/hatcher-library)
- location-aside panel on the [location details page](https://deploy-preview-299--future-wwwlib-previews.netlify.app/locations-and-hours/hatcher-library)
-  Address and time icon on [locations and hours page](https://deploy-preview-299--future-wwwlib-previews.netlify.app/locations-and-hours)

Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [x] Edge

Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
