### PR TITLE
heading levels updated

### DIFF
--- a/src/components/event-card.js
+++ b/src/components/event-card.js
@@ -60,7 +60,7 @@ export default function EventCard (node) {
       <div>
         <Heading
           size='S'
-          level={2}
+          level={3}
           css={{
             display: 'flex',
             flexDirection: 'column',

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -217,6 +217,7 @@ const CardPanel = ({ data }) => {
                 }
                 href={getCardHref(card)}
                 subtitle={getCardSubtitle(card)}
+                headingLevel={title ? '3' : '2'}
                 title={card.title}
                 css={{
                   height: '100%'

--- a/src/reusable/card.js
+++ b/src/reusable/card.js
@@ -1,5 +1,6 @@
 import {
   COLORS,
+  Heading,
   LINK_STYLES,
   MEDIA_QUERIES,
   SPACING,
@@ -13,6 +14,7 @@ import React from 'react';
 export default function Card ({
   title,
   subtitle,
+  headingLevel = '3',
   image,
   href,
   renderAnchor,
@@ -73,7 +75,7 @@ export default function Card ({
       {image && <CardImage image={image} />}
 
       <div>
-        <p role='heading' aria-level='3'>
+        <Heading level={headingLevel}>
           {subtitle && (
             <span
               css={{
@@ -94,7 +96,7 @@ export default function Card ({
           >
             {title}
           </span>
-        </p>
+        </Heading>
 
         {renderChildren()}
       </div>
@@ -115,10 +117,16 @@ export default function Card ({
 Card.propTypes = {
 
   /*
-   * Regular React element.
+  * Regular React element.
+  *
+  */
+  children: PropTypes.node,
+
+  /*
+   * Determine the heading level to render to ensure proper hierarchy on each page.
    *
    */
-  children: PropTypes.node,
+  headingLevel: PropTypes.oneOf(['h3', 'h2']),
 
   /*
    * Let the Card know if it can go horizontal on large screens.

--- a/src/reusable/card.js
+++ b/src/reusable/card.js
@@ -75,7 +75,7 @@ export default function Card ({
       {image && <CardImage image={image} />}
 
       <div>
-        <Heading level={headingLevel} css={{ marginTop: '0 !important' }}>
+        <Heading level={headingLevel} style={{ marginTop: '0' }}>
           {subtitle && (
             <span
               css={{

--- a/src/reusable/card.js
+++ b/src/reusable/card.js
@@ -75,7 +75,7 @@ export default function Card ({
       {image && <CardImage image={image} />}
 
       <div>
-        <Heading level={headingLevel}>
+        <Heading level={headingLevel} css={{ marginTop: '0 !important' }}>
           {subtitle && (
             <span
               css={{

--- a/src/templates/news-landing.js
+++ b/src/templates/news-landing.js
@@ -85,6 +85,7 @@ const NewsLandingTemplate = ({ data }) => {
                           }}
                         >
                           <Card
+                            headingLevel={2}
                             href={item.href}
                             title={item.title}
                             subtitle={item.subtitle}


### PR DESCRIPTION
# Overview
This is a warning in the [baseline accessibility evaluation](https://docs.google.com/document/d/1PGCPqSdbGEgx83_zMgkJvoCHYd3dhtQleoZBwPAgKzQ/edit?usp=sharing).

The heading levels for `<Cards>` and `<EventCards>` is often incorrect.

For the two situations where `<EventCards>` are used, they are both after a `<h2>`, so I changed the event card `<Heading>` to `level={3}`.

The `<Cards>` were previously using aria to define heading levels on a paragraph tag:
`<p role="heading" aria-level="3">`

I changed these to use the `<Heading>` component with the heading level either being assigned or passed to the `<Card>` component. The default heading level is 3.

> This pull request resolve [WEBSITE-135](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-135) and [WEBSITE-141](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-141)

## Testing
Check the following pages to ensure the headings have the proper hierarchical order. These pages are using the `<Card>` component:
- [Find Materials](https://deploy-preview-301--future-wwwlib-previews.netlify.app/find-borrow-request/find-materials) - landing page, standard no image template, no panel title
- [Study Spaces by Building](https://deploy-preview-301--future-wwwlib-previews.netlify.app/visit-and-study/study-spaces/study-spaces-building) - landing page, standard no image template, panel titles
- [Cafes](https://deploy-preview-301--future-wwwlib-previews.netlify.app/visit-and-study/cafes-and-wellbeing/cafes) - basic page, destination template, no panel title
- [Information Desks](https://deploy-preview-301--future-wwwlib-previews.netlify.app/visit-and-study/information-desks) - landing page, destination template, panel titles
- [Library Locations by Campus](https://deploy-preview-301--future-wwwlib-previews.netlify.app/locations-and-hours) - section page, address and hours template, panel titles
- [Arts and Humanities Collecting Areas](https://deploy-preview-301--future-wwwlib-previews.netlify.app/collections/collecting-areas/arts-and-humanities) - landing page, standard template, no panel title
- [Shapiro Library](https://deploy-preview-301--future-wwwlib-previews.netlify.app/locations-and-hours/shapiro-library) - visit page, standard template, panel titles

Check the following two pages to ensure the <EventCards> have the proper hierarchical order:
- The [homepage](https://deploy-preview-301--future-wwwlib-previews.netlify.app/) under "What's Happening"
and
- The [Events and Exhibits page](https://deploy-preview-301--future-wwwlib-previews.netlify.app/visit-and-study/events-and-exhibits).

- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari 
  - [x] Edge 
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- _How to use the feature_.
