### PR TITLE
Update event-card.js

### DIFF
--- a/src/components/event-card.js
+++ b/src/components/event-card.js
@@ -1,9 +1,10 @@
-import { Heading, Icon, SPACING, TYPOGRAPHY } from '../reusable';
+/* eslint-disable camelcase */
 import {
   eventFormatWhen,
   eventFormatWhere,
   EXHIBIT_TYPES
 } from '../utils/events';
+import { Heading, Icon, SPACING, TYPOGRAPHY } from '../reusable';
 import CardImage from '../reusable/card-image';
 import icons from '../reusable/icons';
 import Link from './link';
@@ -17,7 +18,8 @@ export default function EventCard (node) {
     relationships,
     body,
     fields,
-    field_event_date_s_: fieldEventDateS,
+    fieldEventDateS,
+    field_event_date_s_,
     hasBorder = true
   } = node;
   const image
@@ -26,8 +28,8 @@ export default function EventCard (node) {
   const imageData = image
     ? image.localFile.childImageSharp.gatsbyImageData
     : null;
-  const start = fieldEventDateS[0].value;
-  const end = fieldEventDateS[0].end_value;
+  const start = fieldEventDateS ? fieldEventDateS[0].value : field_event_date_s_[0].value;
+  const end = fieldEventDateS ? fieldEventDateS[0].end_value : field_event_date_s_[0].end_value;
   const type = relationships.field_event_type.name;
   const isAnExhibit = EXHIBIT_TYPES.includes(type);
   const useBorder = hasBorder;
@@ -42,7 +44,7 @@ export default function EventCard (node) {
     node
   });
   const to = fields.slug;
-
+  // Console.log(when);
   return (
     <section
       css={{


### PR DESCRIPTION
# Overview
On the [Today and Upcoming page](https://lib.umich.edu/visit-and-study/events-and-exhibits/today-and-upcoming) multiple occurrences of events that happen on the same day but different times would only show the first time for each occurrence. This fix checks if the event node has the `fieldEventDateS` field. If it does, it uses that instead of the  `field_event_date_s_` field. 

![image](https://github.com/user-attachments/assets/d15fecdb-7af6-4280-82bb-106793cf980c)

This is a similar issue as outlined `[in this PR](https://github.com/mlibrary/lib.umich.edu/pull/148)`. That PR didn't account for the case where multiple occurrences can happen on the same day.

> This pull request resolves/closes/fixes [WEBSITE-1234](https://mlit.atlassian.net/browse/WEBSITE-1234).

## Testing
List instructions on how to test the pull request. Some examples:

- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge (the assignee was not able to test the pull request in this browser)
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- _How to use the feature_.
