### PR TITLE
Adding alt text to images

### DIFF
--- a/src/components/page-header.js
+++ b/src/components/page-header.js
@@ -14,6 +14,7 @@ export default function PageHeader ({ breadcrumb, title, summary, image, ...rest
   const imageData = image
     ? image.localFile.childImageSharp.gatsbyImageData
     : null;
+  const imageAlt = image.field_media_image?.field_media_image?.alt || '';
 
   return (
     <div
@@ -78,7 +79,7 @@ export default function PageHeader ({ breadcrumb, title, summary, image, ...rest
                     display: 'none'
                   }
                 }}
-                alt=''
+                alt={imageAlt}
               />
             </React.Fragment>
           )}

--- a/src/components/page-header.js
+++ b/src/components/page-header.js
@@ -12,9 +12,10 @@ import React from 'react';
 
 export default function PageHeader ({ breadcrumb, title, summary, image, ...rest }) {
   const imageData = image
-    ? image.localFile.childImageSharp.gatsbyImageData
+    ? image.relationships.field_media_image.localFile.childImageSharp.gatsbyImageData
     : null;
-  const imageAlt = image?.field_media_image?.field_media_image?.alt || '';
+
+  const imageAlt = image?.field_media_image.alt;
 
   return (
     <div
@@ -92,6 +93,7 @@ export default function PageHeader ({ breadcrumb, title, summary, image, ...rest
 PageHeader.propTypes = {
   breadcrumb: PropTypes.string,
   image: PropTypes.object,
+  imageAlt: PropTypes.string,
   summary: PropTypes.string,
   title: PropTypes.string
 };

--- a/src/components/page-header.js
+++ b/src/components/page-header.js
@@ -14,7 +14,7 @@ export default function PageHeader ({ breadcrumb, title, summary, image, ...rest
   const imageData = image
     ? image.localFile.childImageSharp.gatsbyImageData
     : null;
-  const imageAlt = image.field_media_image?.field_media_image?.alt || '';
+  const imageAlt = image?.field_media_image?.field_media_image?.alt || '';
 
   return (
     <div

--- a/src/components/page-header.js
+++ b/src/components/page-header.js
@@ -1,5 +1,4 @@
 import {
-  BREAKPOINTS,
   Heading,
   Margins,
   MEDIA_QUERIES,

--- a/src/components/page-header.js
+++ b/src/components/page-header.js
@@ -1,4 +1,5 @@
 import {
+  BREAKPOINTS,
   Heading,
   Margins,
   MEDIA_QUERIES,
@@ -15,8 +16,7 @@ export default function PageHeader ({ breadcrumb, title, summary, image, ...rest
     ? image.relationships.field_media_image.localFile.childImageSharp.gatsbyImageData
     : null;
 
-  const imageAlt = image?.field_media_image.alt;
-
+  const imageAlt = image?.field_media_image?.alt || '';
   return (
     <div
       css={{
@@ -59,25 +59,14 @@ export default function PageHeader ({ breadcrumb, title, summary, image, ...rest
           </div>
           {imageData && (
             <React.Fragment>
-              <div
-                css={{
-                  backgroundImage: `url('${imageData.images.fallback.src}')`,
-                  backgroundPosition: 'center',
-                  backgroundRepeat: 'no-repeat',
-                  backgroundSize: 'cover',
-                  display: 'none',
-                  [MEDIA_QUERIES.LARGESCREEN]: {
-                    display: 'block'
-                  },
-                  flex: '0 1 50%'
-                }}
-              />
               <GatsbyImage
                 image={imageData}
                 css={{
+                  flex: '0 1 50%',
                   margin: `0 -${SPACING.M}`,
                   [MEDIA_QUERIES.LARGESCREEN]: {
-                    display: 'none'
+                    margin: 0,
+                    maxHeight: '350px'
                   }
                 }}
                 alt={imageAlt}

--- a/src/components/page-header.js
+++ b/src/components/page-header.js
@@ -1,4 +1,5 @@
 import {
+  BREAKPOINTS,
   Heading,
   Margins,
   MEDIA_QUERIES,
@@ -64,6 +65,9 @@ export default function PageHeader ({ breadcrumb, title, summary, image, ...rest
                   flex: '0 1 50%',
                   margin: `0 -${SPACING.M}`,
                   [MEDIA_QUERIES.LARGESCREEN]: {
+                    'div:first-child > img': {
+                      position: 'absolute !important'
+                    },
                     margin: 0
                   }
                 }}

--- a/src/components/page-header.js
+++ b/src/components/page-header.js
@@ -64,8 +64,7 @@ export default function PageHeader ({ breadcrumb, title, summary, image, ...rest
                   flex: '0 1 50%',
                   margin: `0 -${SPACING.M}`,
                   [MEDIA_QUERIES.LARGESCREEN]: {
-                    margin: 0,
-                    maxHeight: '350px'
+                    margin: 0
                   }
                 }}
                 alt={imageAlt}

--- a/src/components/panels/destination-horizontal-panel.js
+++ b/src/components/panels/destination-horizontal-panel.js
@@ -14,11 +14,11 @@ export default function DestinationHorizontalPanel ({ data }) {
     const floor = getFloor({ node: card });
     const imageData = getImage({ node: card });
     const room = getRoom({ node: card });
-
     return {
       bid: card.relationships.field_room_building.id,
       content: <Html html={card.body.processed} />,
-      image: imageData.localFile.childImageSharp.gatsbyImageData,
+      image: imageData.relationships.field_media_image.localFile.childImageSharp.gatsbyImageData,
+      imageAlt: imageData.field_media_image?.alt,
       linkDestText: `${parentTitle} ${floor}`,
       rid: card.relationships.field_floor.id,
       subtitle: `${parentTitle}, ${floor}, ${room}`,
@@ -60,7 +60,7 @@ const DestinationCard = ({ card }) => {
         }
       }}
     >
-      <CardImage image={card.image} />
+      <CardImage image={card.image} alt={card.imageAlt} />
       <div>
         <Heading
           size='S'

--- a/src/graphql/buildingCardFragment.js
+++ b/src/graphql/buildingCardFragment.js
@@ -31,6 +31,9 @@ export const query = graphql`
     field_hours_different_from_build
     relationships {
       field_media_image {
+        field_media_image {
+          alt
+        }
         relationships {
           field_media_image {
             localFile {

--- a/src/graphql/buildingFragment.js
+++ b/src/graphql/buildingFragment.js
@@ -31,6 +31,9 @@ export const query = graphql`
     field_hours_different_from_build
     relationships {
       field_media_image {
+        field_media_image {
+          alt
+        }
         relationships {
           field_media_image {
             localFile {

--- a/src/graphql/buildingParentFragment.js
+++ b/src/graphql/buildingParentFragment.js
@@ -31,6 +31,9 @@ export const query = graphql`
     field_hours_different_from_build
     relationships {
       field_media_image {
+        field_media_image {
+          alt
+        }
         relationships {
           field_media_image {
             localFile {

--- a/src/graphql/eventFragment.js
+++ b/src/graphql/eventFragment.js
@@ -52,6 +52,9 @@ export const query = graphql`
         name
       }
       field_media_image {
+        field_media_image {
+          alt
+        }
         field_image_caption {
           processed
         }

--- a/src/graphql/locationCardFragment.js
+++ b/src/graphql/locationCardFragment.js
@@ -37,6 +37,9 @@ export const query = graphql`
     field_hours_different_from_build
     relationships {
       field_media_image {
+        field_media_image {
+          alt
+        }
         relationships {
           field_media_image {
             localFile {

--- a/src/graphql/locationFragment.js
+++ b/src/graphql/locationFragment.js
@@ -37,6 +37,9 @@ export const query = graphql`
     field_hours_different_from_build
     relationships {
       field_media_image {
+        field_media_image {
+          alt
+        }
         relationships {
           field_media_image {
             localFile {

--- a/src/graphql/locationParentFragment.js
+++ b/src/graphql/locationParentFragment.js
@@ -37,6 +37,9 @@ export const query = graphql`
     field_hours_different_from_build
     relationships {
       field_media_image {
+        field_media_image {
+          alt
+        }
         relationships {
           field_media_image {
             localFile {

--- a/src/graphql/newsFragment.js
+++ b/src/graphql/newsFragment.js
@@ -21,6 +21,9 @@ export const query = graphql`
         ...textPanelFragment
       }
       field_media_image {
+        field_media_image {
+          alt
+        }
         field_image_caption {
           processed
         }

--- a/src/graphql/pageCardFragment.js
+++ b/src/graphql/pageCardFragment.js
@@ -15,6 +15,9 @@ export const query = graphql`
     }
     relationships {
       field_media_image {
+        field_media_image {
+          alt
+        }
         relationships {
           field_media_image {
             localFile {

--- a/src/graphql/roomCardFragment.js
+++ b/src/graphql/roomCardFragment.js
@@ -62,6 +62,9 @@ export const query = graphql`
         name
       }
       field_media_image {
+        field_media_image {
+          alt
+        }
         relationships {
           field_media_image {
             localFile {

--- a/src/graphql/roomFragment.js
+++ b/src/graphql/roomFragment.js
@@ -62,6 +62,9 @@ export const query = graphql`
         name
       }
       field_media_image {
+        field_media_image {
+          alt
+        }
         relationships {
           field_media_image {
             localFile {

--- a/src/graphql/sectionCardFragment.js
+++ b/src/graphql/sectionCardFragment.js
@@ -15,6 +15,9 @@ export const query = graphql`
     }
     relationships {
       field_media_image {
+        field_media_image {
+          alt
+        }
         relationships {
           field_media_image {
             localFile {

--- a/src/graphql/sectionFragment.js
+++ b/src/graphql/sectionFragment.js
@@ -28,6 +28,9 @@ export const query = graphql`
         field_machine_name
       }
       field_media_image {
+        field_media_image {
+          alt
+        }
         relationships {
           field_media_image {
             localFile {

--- a/src/reusable/card-image.js
+++ b/src/reusable/card-image.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { SPACING } from '../reusable';
 
-export default function CardImage ({ image }) {
+export default function CardImage ({ image, alt }) {
   return (
     <GatsbyImage
       image={image}
-      alt={image.alt || ''}
+      alt={alt || ''}
       css={{
         aspectRatio: '3 / 2',
         backgroundColor: 'var(--color-blue-100)',
@@ -21,7 +21,6 @@ export default function CardImage ({ image }) {
 }
 
 CardImage.propTypes = {
-  image: PropTypes.shape({
-    alt: PropTypes.string
-  })
+  alt: PropTypes.string,
+  image: PropTypes.object
 };

--- a/src/reusable/card-image.js
+++ b/src/reusable/card-image.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { SPACING } from '../reusable';
 
-export default function CardImage ({ image, alt }) {
+export default function CardImage ({ image, alt = '' }) {
   return (
     <GatsbyImage
       image={image}
-      alt={alt || ''}
+      alt={alt}
       css={{
         aspectRatio: '3 / 2',
         backgroundColor: 'var(--color-blue-100)',

--- a/src/templates/destination-body.js
+++ b/src/templates/destination-body.js
@@ -36,6 +36,7 @@ const DestinationTemplate = ({ data }) => {
   const imageData = image
     ? image.localFile.childImageSharp.gatsbyImageData
     : null;
+  const imageAlt = relationships.field_media_image?.field_media_image?.alt || '';
 
   return (
     <TemplateLayout node={node}>
@@ -94,7 +95,7 @@ const DestinationTemplate = ({ data }) => {
                   marginBottom: SPACING['2XL'],
                   width: '100%'
                 }}
-                alt=''
+                alt={imageAlt}
               />
             </div>
 

--- a/src/templates/destination-full.js
+++ b/src/templates/destination-full.js
@@ -20,6 +20,7 @@ const DestinationTemplate = ({ data }) => {
   const imageData
     = relationships?.field_media_image?.relationships?.field_media_image
       ?.localFile?.childImageSharp?.gatsbyImageData;
+  const imageAlt = relationships?.field_media_image?.field_media_image?.alt || '';
 
   return (
     <TemplateLayout node={node}>
@@ -77,7 +78,7 @@ const DestinationTemplate = ({ data }) => {
                 borderRadius: '2px',
                 width: '100%'
               }}
-              alt=''
+              alt={imageAlt}
             />
           )}
 

--- a/src/templates/event.js
+++ b/src/templates/event.js
@@ -18,6 +18,7 @@ const EventTemplate = ({ data }) => {
   const { slug } = fields;
   const image
     = relationships?.field_media_image?.relationships.field_media_image;
+  const imageAlt = relationships?.field_media_image?.field_media_image?.alt || '';
   const imageData = image
     ? image.localFile.childImageSharp.gatsbyImageData
     : null;
@@ -25,7 +26,6 @@ const EventTemplate = ({ data }) => {
     = relationships?.field_media_image?.field_image_caption?.processed;
   const contact = relationships?.field_library_contact;
   const eventContacts = relationships?.field_non_library_event_contact;
-
   return (
     <TemplateLayout node={node}>
       <Margins>
@@ -66,7 +66,7 @@ const EventTemplate = ({ data }) => {
                   borderRadius: '2px',
                   width: '100%'
                 }}
-                alt=''
+                alt={imageAlt}
               />
               {imageCaptionHTML && (
                 <figcaption

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -27,10 +27,7 @@ export default function LandingTemplate ({ data }) {
         breadcrumb={fields.breadcrumb}
         title={field_title_context}
         summary={body ? body.summary : null}
-        image={
-          relationships.field_media_image
-          && relationships.field_media_image
-        }
+        image={relationships.field_media_image || null}
       />
       <Margins>
         {body && <Html html={body.processed} />} <Panels data={bodyPanels} />

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -29,7 +29,7 @@ export default function LandingTemplate ({ data }) {
         summary={body ? body.summary : null}
         image={
           relationships.field_media_image
-          && relationships.field_media_image.relationships.field_media_image
+          && relationships.field_media_image
         }
       />
       <Margins>

--- a/src/templates/news.js
+++ b/src/templates/news.js
@@ -26,6 +26,7 @@ const NewsTemplate = ({ data }) => {
   const imageData = image
     ? image.localFile.childImageSharp.gatsbyImageData
     : null;
+  const imageAlt = relationships?.field_media_image?.field_media_image?.alt || '';
   const imageCaption
     = relationships.field_media_image
     && relationships.field_media_image.field_image_caption
@@ -88,7 +89,7 @@ const NewsTemplate = ({ data }) => {
                   borderRadius: '2px',
                   width: '100%'
                 }}
-                alt=''
+                alt={imageAlt}
               />
               {imageCaption && (
                 <figcaption

--- a/src/templates/section.js
+++ b/src/templates/section.js
@@ -43,7 +43,7 @@ const SectionTemplate = ({ data, ...rest }) => {
   const isRootPage = Boolean(fieldRootPage);
   const pageHeaderImage
     = relationships.field_media_image
-    && relationships.field_media_image.relationships.field_media_image;
+    && relationships.field_media_image;
   const hasBody = body && body.processed && body.processed.length;
   /*
    *Use the parent page if not the root

--- a/src/templates/visit.js
+++ b/src/templates/visit.js
@@ -28,6 +28,7 @@ export default function VisitTemplate ({ data, ...rest }) {
     field_access: fieldAccess
   } = node;
   const [parentNode] = relationships.field_parent_page;
+  const imageAlt = relationships.field_media_image?.field_media_image?.alt;
   const isRootPage = Boolean(fieldRootPage);
   const { field_visit: fieldVisit, field_amenities: fieldAmenities } = relationships;
   const { bodyPanels, fullPanels } = transformNodePanels({ node });

--- a/src/templates/visit.js
+++ b/src/templates/visit.js
@@ -28,7 +28,6 @@ export default function VisitTemplate ({ data, ...rest }) {
     field_access: fieldAccess
   } = node;
   const [parentNode] = relationships.field_parent_page;
-  const imageAlt = relationships.field_media_image?.field_media_image?.alt;
   const isRootPage = Boolean(fieldRootPage);
   const { field_visit: fieldVisit, field_amenities: fieldAmenities } = relationships;
   const { bodyPanels, fullPanels } = transformNodePanels({ node });
@@ -40,7 +39,7 @@ export default function VisitTemplate ({ data, ...rest }) {
           title={title}
           summary={body ? body.summary : null}
           image={
-            relationships.field_media_image.relationships.field_media_image
+            relationships.field_media_image
           }
         />
       </header>

--- a/src/utils/get-image.js
+++ b/src/utils/get-image.js
@@ -3,7 +3,7 @@ export default function getImage ({ node }) {
 
   const imageData
     = relationships.field_media_image
-    && relationships.field_media_image.relationships.field_media_image;
+    && relationships.field_media_image;
 
   return imageData;
 }


### PR DESCRIPTION
# Overview
This PR adds alt text to images. Content editors are adding alt text to images but we are not always pulling them into the images. We don't want to pull alt text into ALL images, though, since some are decorative.

Several GraphQL queries needed to be updated to pull in the alt text. Once complete, the components were updated to pull that alt text and apply it.

If there is no alt text provided by the CMS, the image is marked as decorative with an empty alt.

The following JIRA ticket is an amalgamation of 11 sub-tasks that cover alt text on various templates / components.

> This pull request resolves [WEBSITE-17](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-17).

## Anything else?
I also took the time to update the `PageHeader` component ([example](http://localhost:8000/locations-and-hours)). It was previously using two elements to create the image, one for desktop and one for mobile. The desktop element was using a `background-image` css property so we couldn't easily put alt text on that. It's now all one element and has specific styling for desktop and mobile view. This update should not change how the image looks on the page.

Most of these components were getting image information from the GraphQL tree `relationships.field_media_image.relationships.field_media_image`. The alt text lives in `relationships.field_media_image.field_media_image.alt` so I ambiguated the tree up to `relationships.field_media_image` for the image data and then further refined it from there.

## Testing
**Check the following pages to make sure they have alt text on the images:**
[WEBSITE-43](https://mlit.atlassian.net/browse/WEBSITE-43)
- [x] [Location visit template](https://deploy-preview-308--future-wwwlib-previews.netlify.app/locations-and-hours/hatcher-library)
- [x] [Building visit template](https://deploy-preview-308--future-wwwlib-previews.netlify.app/locations-and-hours/shapiro-library)
- [x] [Room visit template](https://deploy-preview-308--future-wwwlib-previews.netlify.app/locations-and-hours/computer-and-video-game-archive)

[WEBSITE-44](https://mlit.atlassian.net/browse/WEBSITE-44)
- [x] [Room body-width](https://deploy-preview-308--future-wwwlib-previews.netlify.app/visit-and-study/creation-and-learning-spaces/conservation-lab)
- [x] [Location body-width](https://deploy-preview-308--future-wwwlib-previews.netlify.app/visit-and-study/creation-and-learning-spaces/shapiro-design-lab/pie-space)
- [x] [Basic body-width](https://deploy-preview-308--future-wwwlib-previews.netlify.app/visit-and-study/computing-and-technology/specialized-technology/anatomage-table)
- [x] [Room full-width](https://deploy-preview-308--future-wwwlib-previews.netlify.app/locations-and-hours/hatcher-library/hatcher-north-information-services-desk)
- [x] [Location full-width](https://deploy-preview-308--future-wwwlib-previews.netlify.app/locations-and-hours/hatcher-library/ask-librarian-desk)

[WEBSITE-45](https://mlit.atlassian.net/browse/WEBSITE-45)
- [x] [News page template](https://deploy-preview-308--future-wwwlib-previews.netlify.app/about-us/news/librarian-awards-2024)

[WEBSITE-46](https://mlit.atlassian.net/browse/WEBSITE-46)
- [x] [Events page template](https://deploy-preview-308--future-wwwlib-previews.netlify.app/visit-and-study/events-and-exhibits/today-and-upcoming/being-mixed-race-mono-racially-organized)

[WEBSITE-47](https://mlit.atlassian.net/browse/WEBSITE-47)
- [x] [Horizontal destination panel template](https://deploy-preview-308--future-wwwlib-previews.netlify.app/visit-and-study/cafes-and-wellbeing/lactation-rooms)

**The following pages should NOT have alt text on the panels**
[WEBSITE-48](https://mlit.atlassian.net/browse/WEBSITE-48)
- [x] [Standard card panel](https://deploy-preview-308--future-wwwlib-previews.netlify.app/locations-and-hours/clark-library/collections)

[WEBSITE-49](https://mlit.atlassian.net/browse/WEBSITE-49)
- [x] [Address and Hours card panel](https://deploy-preview-308--future-wwwlib-previews.netlify.app/locations-and-hours)

- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari  (the assignee was not able to test the pull request in this browser)
  - [x] Edge
- Run accessibility tests:
  - [x] ARC Toolkit
  - [x] axe DevTools
