### PR TITLE
Updated events to use proper end time value

### DIFF
--- a/src/components/panels/events-and-exhibits-panel.js
+++ b/src/components/panels/events-and-exhibits-panel.js
@@ -71,11 +71,10 @@ export default function EventsAndExhibitsPanel () {
     // Only process todaysEvents if it hasn't been done already.
     if (events && todaysEvents === null) {
       // UseEffects are only client side, so we can use now here.
-
       // Get Today's events.
       const getTodaysEvents = events.filter((event) => {
-        const start = new Date(event.field_event_date_s_[0].value);
-        const end = new Date(event.field_event_date_s_[0].end_value);
+        const start = new Date(event.fieldEventDateS ? event.fieldEventDateS[0].value : event.field_event_date_s_[0].value);
+        const end = new Date(event.fieldEventDateS ? event.fieldEventDateS[0].end_value : event.field_event_date_s_[0].end_value);
         const type = event.relationships.field_event_type.name;
         // We don't want exhibits in the events area.
         if (EXHIBIT_TYPES.includes(type)) {
@@ -96,7 +95,7 @@ export default function EventsAndExhibitsPanel () {
 
       // Get upcoming events.
       const getUpcomingEvents = events.filter((event) => {
-        const start = new Date(event.field_event_date_s_[0].value);
+        const start = new Date(event.fieldEventDateS ? event.fieldEventDateS[0].value : event.field_event_date_s_[0].value);
         const type = event.relationships.field_event_type.name;
 
         // We don't want exhibits in the events area.

--- a/src/components/panels/whats-happening-panel.js
+++ b/src/components/panels/whats-happening-panel.js
@@ -67,8 +67,10 @@ export default function WhatsHappening () {
       );
 
       const sortedEvents = sortEventsByStartDate({
-        events: joinedEvents
+        events: joinedEvents,
+        onlyTodayOrAfter: true
       });
+
       // Only keep 3
       setEvents(sortedEvents.slice(0, 3));
     }

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -211,9 +211,8 @@ export const sortEventsByStartDate = ({ events, onlyTodayOrAfter = false }) => {
 
   if (onlyTodayOrAfter) {
     const eventEndTimeIsAfterNow = (event) => {
-      const eventEndTime = new Date(event.field_event_date_s_[0].end_value);
-      const now = new Date(new Date().toLocaleDateString('en-US', { timeZone: 'America/New_York' }));
-
+      const eventEndTime = new Date(event.fieldEventDateS ? event.fieldEventDateS[0].end_value : event.field_event_date_s_[0].end_value);
+      const now = new Date(new Date().toLocaleString('en', { timeZone: 'America/New_York' }));
       const result = eventEndTime > now;
 
       return result;


### PR DESCRIPTION
# Overview
A couple of pages are not displaying future events properly.

The two pages that are being impacted by this are:
- The [Today and Upcoming page](https://www.lib.umich.edu/visit-and-study/events-and-exhibits/today-and-upcoming)
- The "What's Happening" panel on [the homepage](https://www.lib.umich.edu)

Here's what the current live site looks like:
![image](https://github.com/user-attachments/assets/079529de-6d58-4b30-9c21-bcd6893ca939)
There should be an event under "Today's Events" like so:
![image](https://github.com/user-attachments/assets/1295252a-ac4e-4f7b-95c5-5c213512da82)

Since the event [TEDx Talks on Being Biracial](https://lib.umich.edu/visit-and-study/events-and-exhibits/today-and-upcoming/tedx-talks-being-biracial) has multiple times and first time has passed, future instances of the event are not currently showing up.

This is also the case with the [Exhibit Tour: Being Mixed Race](Exhibit Tour: Being Mixed Race) event. The next event instance is on October 11, but since the first instance from September 26 has passed, all future events aren't showing.

## The Fix

 If an event has more than one occurance, it's given an entry for each time occurrence under the  `field_event_date_s_` entry. We also flatten the event into multiple events and the start and end times get placed into a new field `fieldEventDateS`. We should be using this field (if it exists) versus the `field_event_date_s_` for checking event times. I've added ternary operators to check and use this field if it exists where appropriate. 

> This pull request fixes [WEBSITE-162](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-162).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [x] Edge (the assignee was not able to test the pull request in this browser)
