### PR TITLE
WEBSITE-153-remove-public-profile-condition

### DIFF
--- a/plugins/gatsby-source-umich-lib/gatsby-node.js
+++ b/plugins/gatsby-source-umich-lib/gatsby-node.js
@@ -479,12 +479,11 @@ exports.createPages = ({ actions, graphql }) => {
               }
             }
            profiles: allUserUser(
-              filter: { field_make_profile_public: { eq: true } }
+              filter: {name: {ne: null}}
             ) {
               edges {
                 node {
                   __typename
-                  field_make_profile_public
                   field_user_display_name
                   field_user_work_title
                   name

--- a/plugins/gatsby-source-umich-lib/gatsby-node.js
+++ b/plugins/gatsby-source-umich-lib/gatsby-node.js
@@ -478,13 +478,10 @@ exports.createPages = ({ actions, graphql }) => {
                 }
               }
             }
-            profiles: allUserUser(
-              filter: { field_make_profile_public: { eq: true } }
-            ) {
+            profiles: allUserUser{
               edges {
                 node {
                   __typename
-                  field_make_profile_public
                   field_user_display_name
                   field_user_work_title
                   name

--- a/plugins/gatsby-source-umich-lib/gatsby-node.js
+++ b/plugins/gatsby-source-umich-lib/gatsby-node.js
@@ -653,6 +653,8 @@ exports.createPages = ({ actions, graphql }) => {
         const { profiles } = result.data;
 
         profiles.edges.forEach(({ node }) => {
+          console.log(JSON.stringify(node, null, 2));
+
           const profileTemplate = path.resolve(`src/templates/profile.js`);
 
           createPage({

--- a/plugins/gatsby-source-umich-lib/gatsby-node.js
+++ b/plugins/gatsby-source-umich-lib/gatsby-node.js
@@ -478,10 +478,13 @@ exports.createPages = ({ actions, graphql }) => {
                 }
               }
             }
-            profiles: allUserUser{
+           profiles: allUserUser(
+              filter: { field_make_profile_public: { eq: true } }
+            ) {
               edges {
                 node {
                   __typename
+                  field_make_profile_public
                   field_user_display_name
                   field_user_work_title
                   name

--- a/plugins/gatsby-source-umich-lib/gatsby-node.js
+++ b/plugins/gatsby-source-umich-lib/gatsby-node.js
@@ -655,8 +655,6 @@ exports.createPages = ({ actions, graphql }) => {
         const { profiles } = result.data;
 
         profiles.edges.forEach(({ node }) => {
-          console.log(JSON.stringify(node, null, 2));
-
           const profileTemplate = path.resolve(`src/templates/profile.js`);
 
           createPage({

--- a/src/reusable/index.js
+++ b/src/reusable/index.js
@@ -1,5 +1,5 @@
 import { Breadcrumb, BreadcrumbItem } from './breadcrumb';
-import { BREAKPOINTS, GlobalStyleSheet, INTENT_COLORS, LargeScreen, lightOrDark, LINK_STYLES, Margins, MEDIA_QUERIES, SmallScreen, SPACING, TYPOGRAPHY, Z_SPACE } from './utils';
+import { BREAKPOINTS, GlobalStyleSheet, INTENT_COLORS, LargeScreen, LINK_STYLES, Margins, MEDIA_QUERIES, SmallScreen, SPACING, TYPOGRAPHY, Z_SPACE } from './utils';
 import { Expandable, ExpandableButton, ExpandableChildren, ExpandableProvider } from './expandable/index';
 import Icon, { icons } from './icon';
 import Alert from './alert';
@@ -22,7 +22,6 @@ export {
   TYPOGRAPHY,
   LINK_STYLES,
   GlobalStyleSheet,
-  lightOrDark,
   Alert,
   Margins,
   LargeScreen,


### PR DESCRIPTION
# Overview
We need to remove the reliance on `field_make_profile_public` in staff data being `1` to publish staff profiles. The field is no longer necessary and causes issues when temporary employee are later hired in a regular appointment.

This field is a holdover from when we launched the website redesign and were transitioning from folks having 2 separate profiles (website and intranet), to managing both via the intranet. During the transition period, we gave employees the option to check the “make profile public” box when they were ready to release their updated profile to the preview website and then had a drop date when we flipped everyone. 

The [staff api](https://cms.lib.umich.edu/api/staff) shows that every person has a `field_make_profile_public` set to `1` (true). I removed the `field_make_profile_public` from the `allUserUser` in `gatsby-node.js`. The `field_make_profile_public` was also being used to filter all data objects and select the profile data objects where it `eq: true`, so I replaced the filter to check if the `name` field doesn't equal `null`. This will make sure we're only returning staff nodes and not all nodes (buildings, locations, rooms, etc.) in this query.

> This pull request resolves [WEBSITE-153](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-153).

## Anything else?
_BONUS:_ I saw in the build logs we still had references to the `lightOrDark` utility function that was removed as part of the summer cleanup. I removed those last dependencies.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari (the assignee was not able to test the pull request in this browser)
  - [x] Edge

The [staff directory](https://deploy-preview-310--future-wwwlib-previews.netlify.app/about-us/staff-directory?) and all contents should be identical in this PR [as it is in prod](https://lib.umich.edu/about-us/staff-directory?)
