### PR TITLE
WEBSITE-164 Adjust colors for icons in locationAside to meet minimum acceptable contrast

### DIFF
--- a/src/components/location-aside.js
+++ b/src/components/location-aside.js
@@ -10,6 +10,7 @@ import React from 'react';
 const LayoutWithIcon = ({
   // eslint-disable-next-line react/prop-types
   d: data,
+  color,
   palette,
   children
 }) => {
@@ -29,7 +30,7 @@ const LayoutWithIcon = ({
             alignItems: 'center',
             background: `var(--color-${palette}-100)`,
             borderRadius: '50%',
-            color: `var(--color-${palette}-300)`,
+            color: `var(--color-${palette}-${color})`,
             display: 'flex',
             height: '2.5rem',
             justifyContent: 'center',
@@ -46,6 +47,7 @@ const LayoutWithIcon = ({
 
 LayoutWithIcon.propTypes = {
   children: PropTypes.node,
+  color: PropTypes.string,
   data: PropTypes.string,
   palette: PropTypes.string
 };
@@ -65,7 +67,7 @@ export default function LocationAside ({ node }) {
           marginBottom: SPACING['3XL']
         }}
       >
-        <LayoutWithIcon d={icons.clock} palette='indigo'>
+        <LayoutWithIcon d={icons.clock} palette='indigo' color='400'>
           <Heading
             level={2}
             size='M'
@@ -91,7 +93,7 @@ export default function LocationAside ({ node }) {
           }
         }}
       >
-        <LayoutWithIcon d={icons.address} palette='orange'>
+        <LayoutWithIcon d={icons.address} palette='orange' color='500'>
           <Heading
             level={2}
             size='M'
@@ -105,7 +107,7 @@ export default function LocationAside ({ node }) {
           <Address node={node} directions={true} kind='full' />
         </LayoutWithIcon>
 
-        <LayoutWithIcon d={icons.phone} palette='green'>
+        <LayoutWithIcon d={icons.phone} palette='green' color='500'>
           <Heading
             level={2}
             size='M'


### PR DESCRIPTION
# Overview
Problem: When we completed the accessibility warning remediation for the maize icons, we missed that none of the icons that sit on top of a circle background meet minimum accessible contrast requirements.

The following meet minimum: 
- Hours: indigo-100 and indigo-400
- Address: organge-100 and organge-500
- Contact: green-100 and green-500

> This pull request resolves [WEBSITE-164](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-164).

## Testing
List instructions on how to test the pull request. Some examples:

- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari  (the assignee was not able to test the pull request in this browser)
  - [x] Edge
