### PR TITLE
Added left border for active page

### DIFF
--- a/src/components/navigation/side-navigation.js
+++ b/src/components/navigation/side-navigation.js
@@ -79,11 +79,13 @@ const SideNavLink = ({ path, item, children, ...rest }) => {
             textDecoration: 'underline'
           },
           alignItems: 'center',
+          borderLeft: isActive ? 'solid 4px var(--color-teal-400)' : 'none',
           color: isActive ? 'var(--color-teal-400)' : 'inherit',
           display: 'flex',
           fontWeight: isActive ? '700' : 'inherit',
           justifyContent: 'space-between',
-          paddingBottom: renderChildren ? SPACING.XS : SPACING.M,
+          paddingBottom: SPACING.M,
+          paddingLeft: isActive ? SPACING.S : SPACING.M,
           paddingRight: SPACING.S,
           paddingTop: SPACING.M
         }}
@@ -117,8 +119,9 @@ const SideNavLink = ({ path, item, children, ...rest }) => {
                   path={path}
                   item={child}
                   css={{
-                    padding: `${SPACING.XS} 0`,
-                    paddingLeft: SPACING.M
+                    marginLeft: SPACING.M,
+                    paddingBottom: SPACING.XS,
+                    paddingTop: SPACING.XS
                   }}
                 >
                   {child.text}

--- a/src/components/navigation/side-navigation.js
+++ b/src/components/navigation/side-navigation.js
@@ -95,7 +95,7 @@ const SideNavLink = ({ path, item, children, ...rest }) => {
         {hasChildren && (
           <span
             css={{
-              color: 'var(--color-neutral-400)',
+              color: isActive ? 'var(--color-teal-400)' : 'var(--color-neutral-400)',
               lineHeight: '1',
               paddingLeft: SPACING.XS
             }}


### PR DESCRIPTION
# Overview
This PR adds a vertical line to the left of the active page in the sidenav, similar to the design system ([Example](https://design-system.lib.umich.edu/visual-elements/typography/)) by utilizing a `border-left`.

> This pull request resolves [WEBSITE-136](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-136).

## Testing
Navigate to a page with a side nav and sub pages. [Example page here from deploy URL](https://deploy-preview-320--future-wwwlib-previews.netlify.app/visit-and-study/study-spaces/quiet-study-spaces). Click through the side nav (including children pages) and make sure the padding is consistent.

- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari (the assignee was not able to test the pull request in this browser)
  - [x] Edge
- Run accessibility tests:
  - [x] Screen Reader (NVDA)
