### PR TITLE
Added Workshops section to template

### DIFF
--- a/src/components/panels/events-and-exhibits-panel.js
+++ b/src/components/panels/events-and-exhibits-panel.js
@@ -213,13 +213,14 @@ export default function EventsAndExhibitsPanel () {
             size='M'
             css={{
               borderTop: `solid 1px var(--color-neutral-100)`,
+              marginBottom: SPACING.S,
               marginTop: SPACING.L,
               paddingTop: SPACING.M
             }}
           >
             Workshops
           </Heading>
-          We offer workshops on a range of topics.
+          We offer workshops on a range of topics. See our
           {' '}
           <Link to='https://ttc.iss.lsa.umich.edu/ttc/sessions/upcoming/sponsor/university-library/'>
             list of current offerings

--- a/src/components/panels/events-and-exhibits-panel.js
+++ b/src/components/panels/events-and-exhibits-panel.js
@@ -208,17 +208,17 @@ export default function EventsAndExhibitsPanel () {
           <Link to='https://visitor.r20.constantcontact.com/manage/optin?v=001cDYOOus5TIdow4bzSVycvvOQHeBTvaw-u-NrxVEBWd7CK3DPmM7o6fTauJmkB-PmyMdNV2isg8l8Y3gsqV07er-4bFAo3fZNo1cYkbzohp4%3D'>
             Sign up for email updates
           </Link>
-
-          <h2
+          <Heading
+            level={2}
+            size='M'
             css={{
               borderTop: `solid 1px var(--color-neutral-100)`,
-              fontWeight: '700',
               marginTop: SPACING.L,
               paddingTop: SPACING.M
             }}
           >
             Workshops
-          </h2>
+          </Heading>
           We offer workshops on a range of topics.
           {' '}
           <Link to='https://ttc.iss.lsa.umich.edu/ttc/sessions/upcoming/sponsor/university-library/'>

--- a/src/components/panels/events-and-exhibits-panel.js
+++ b/src/components/panels/events-and-exhibits-panel.js
@@ -208,6 +208,23 @@ export default function EventsAndExhibitsPanel () {
           <Link to='https://visitor.r20.constantcontact.com/manage/optin?v=001cDYOOus5TIdow4bzSVycvvOQHeBTvaw-u-NrxVEBWd7CK3DPmM7o6fTauJmkB-PmyMdNV2isg8l8Y3gsqV07er-4bFAo3fZNo1cYkbzohp4%3D'>
             Sign up for email updates
           </Link>
+
+          <h2
+            css={{
+              borderTop: `solid 1px var(--color-neutral-100)`,
+              fontWeight: '700',
+              marginTop: SPACING.L,
+              paddingTop: SPACING.M
+            }}
+          >
+            Workshops
+          </h2>
+          We offer workshops on a range of topics.
+          {' '}
+          <Link to='https://ttc.iss.lsa.umich.edu/ttc/sessions/upcoming/sponsor/university-library/'>
+            list of current offerings
+          </Link>
+          . U-M authentication is required to register.
         </TemplateSide>
       </Template>
     </div>


### PR DESCRIPTION
# Overview
Added a "Workshops" section to the `events-and-exhibits-panel` with the following criteria:

- Add another horizontal line after “sign up for email updates” (`borderTop` on the `<h2>`)
- Add Workshops as an h2
- Add body text:
We offer workshops on a range of topics. See our [list of current offerings](https://ttc.iss.lsa.umich.edu/ttc/sessions/upcoming/sponsor/university-library/). U-M authentication is required to register.

Add links to any documentation or issues that can help give more background information. Is the pull request related to a GitHub or JIRA issue? Link to them while using [closing keywords](https://docs.github.com/articles/closing-issues-using-keywords), like so:

> This pull request resolves [WEBSITE-156](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-156).

## Testing
Take a look at the Today and Upcoming Events page ([deploy URL](https://deploy-preview-321--future-wwwlib-previews.netlify.app/visit-and-study/events-and-exhibits/today-and-upcoming)) to see the new Workshops section in the location-aside.

- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari (the assignee was not able to test the pull request in this browser)
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
  - [x] NVDA screen reader
