### PR TITLE
Update previews.yml

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -53,14 +53,14 @@ jobs:
           output: |
             {"summary":"${{ env.DEPLOY_URL }}" }
       ## Notify Slack if build fails
-      - name: Send custom JSON data to Slack workflow
-        if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          payload: |
-            {
-              "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "message": "${{ vars.NAME }} build and deploy failed"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+      #- name: Send custom JSON data to Slack workflow
+      #  if: ${{ failure() }}
+      #  uses: slackapi/slack-github-action@v1.25.0
+      #  with:
+      #    payload: |
+      #      {
+      #        "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+      #        "message": "${{ vars.NAME }} build and deploy failed"
+      #      }
+      #  env:
+      #    SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}


### PR DESCRIPTION
Updating previews.yaml to exclude slack notifications on failed build. I'm the only one that needs to know if builds fail for previews and I'm usually monitoring it since I trigger the builds myself.