### PR TITLE
Removed slideshare from profile and added bluesky

### DIFF
--- a/src/graphql/userFragment.js
+++ b/src/graphql/userFragment.js
@@ -32,6 +32,10 @@ export const query = graphql`
       title
       uri
     }
+    field_bluesky {
+      __typename
+      uri
+    }
     field_linkedin {
       __typename
       uri
@@ -41,10 +45,6 @@ export const query = graphql`
       uri
     }
     field_instagram {
-      __typename
-      uri
-    }
-    field_slideshare {
       __typename
       uri
     }

--- a/src/templates/profile.js
+++ b/src/templates/profile.js
@@ -487,14 +487,14 @@ const SocialLinks = ({
   field_linkedin,
   field_facebook,
   field_instagram,
-  field_slideshare,
+  field_bluesky,
   field_twitter
 }) => {
   const links = [
     field_linkedin,
     field_facebook,
     field_instagram,
-    field_slideshare,
+    field_bluesky,
     field_twitter
   ].filter((linkItem) => {
     return linkItem && linkItem.uri;
@@ -527,10 +527,10 @@ const SocialLinks = ({
 };
 
 SocialLinks.propTypes = {
+  field_bluesky: PropTypes.any,
   field_facebook: PropTypes.any,
   field_instagram: PropTypes.any,
   field_linkedin: PropTypes.any,
-  field_slideshare: PropTypes.any,
   field_twitter: PropTypes.any
 };
 


### PR DESCRIPTION
# Overview
This PR simply removes SlideShare from staff profiles and adds Bluesky in its place (between Instagram and X).

Add links to any documentation or issues that can help give more background information. Is the pull request related to a GitHub or JIRA issue? Link to them while using [closing keywords](https://docs.github.com/articles/closing-issues-using-keywords), like so:

> This pull request resolves [WEBSITE-189](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-189).

## Testing
List instructions on how to test the pull request. Some examples:

- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] NVDA Screenreader (label is working and aria-hidden is working on the icon)
- _How to use the feature_.
  - npm run start
  - navigate to Heidi's profile to confirm Bluesky is appearing ([localhost link](http://localhost:8000/users/heidisb))
  - navigate to PF's profile to confirm SlideShare is gone ([localhost link](http://localhost:8000/users/pfa))
