### PR TITLE
[WEBSITE-192]Inconsistent extra line break in last Standard Card of panel (Firefox only)

### DIFF
--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -90,9 +90,9 @@ const PanelList = ({ children, twoColumns, disableLargeScreenStyles = false, ...
     },
     '> li': {
       breakInside: 'avoid',
+      display: 'inline-block',
       marginBottom: 0,
-      marginTop: SPACING.XL,
-      overflow: 'hidden'
+      marginTop: SPACING.XL
     },
     '> li:first-of-type': {
       marginTop: 0

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -91,7 +91,8 @@ const PanelList = ({ children, twoColumns, disableLargeScreenStyles = false, ...
     '> li': {
       breakInside: 'avoid',
       marginBottom: 0,
-      marginTop: SPACING.XL
+      marginTop: SPACING.XL,
+      overflow: 'hidden'
     },
     '> li:first-of-type': {
       marginTop: 0


### PR DESCRIPTION
# Overview
## The Problem
A couple of Web Content Coordinators inadvertently discovered this weird CSS bug during their biennial landing page content review. The last card in a list sometimes has extra line breaks in the summary.

- This only happens in Firefox
- It resolves itself when you scale the screen.
- The last card in the last panel is more consistently broken between breakpoints. The last card in other lists ONLY breaks at a very specific pixel resolution when scaling up, not down. Super weird.
- It only happens for Standard (no image) Card Templates.

Here are four live examples:
- [https://lib.umich.edu/research-and-scholarship/copyright-service](https://lib.umich.edu/research-and-scholarship/copyright-services) - page has 3 panels and it’s the last one.
- [https://lib.umich.edu/find-borrow-request ](https://lib.umich.edu/find-borrow-request )
- [https://lib.umich.edu/research-and-scholarship/help-research ](https://lib.umich.edu/research-and-scholarship/help-research )
- [https://lib.umich.edu/collections/collecting-areas ](https://lib.umich.edu/collections/collecting-areas )

## The Fix
I'm fairly confident this is a bug in Firefox. I found quite a few bug reports and help articles on FF forums that were semi-related. Since this is such a unique issue and is probably from some weird combination of multi-column CSS grid, list items, CSS reset, and our custom styles that is causing the issue, it's hard to track down what exactly is causing this, though.

I can't recreate the issue in codepen, but adding an `overflow: hidden` to the `list-items` seems to fix the issue on Lib. This fix does impact other browsers as far as I can tell.

> This pull request fixes [WEBSITE-192](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-192).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari (the assignee was not able to test the pull request in this browser)
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- _How to use the feature_.
  - `npm run start` the app
  - Check the pages from above in different browsers. I found the issue appearing and disappearing as I scaled the window up and down slowly.
