### PR TITLE
[WEBSITE-188] Add support for Amenities in Visit template for Room CTs

### DIFF
--- a/src/graphql/roomFragment.js
+++ b/src/graphql/roomFragment.js
@@ -101,6 +101,13 @@ export const query = graphql`
           processed
         }
       }
+      field_amenities {
+        weight
+        name
+        description {
+          processed
+        }
+      }
       field_panels {
         ...linkPanelFragment
         ...cardPanelFragment


### PR DESCRIPTION
# Overview
We use the `field_amenities` on our location and building fragments to populate the Amenities field on our Visit templates. See [the Hatcher visit page](https://lib.umich.edu/locations-and-hours/hatcher-library) to see it in action.

For the first time, a room has amenities but we've never pulled that field in to the room fragment. [The Askwith Media Library visit](https://lib.umich.edu/locations-and-hours/askwith-media-library) page had amenities added but they're not showing up since we don't pull that in from the `roomFragment`.

This PR adds the `field_amenities` and all the fields needed for rendering to the `roomFragment` query.

> This pull request resolves [WEBSITE-188](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-188).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari (the assignee was not able to test the pull request in this browser)
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
- _How to use the feature_.
- `npm run start` the app and check [the Askwith Media Library page](http://localhost:8000/locations-and-hours/askwith-media-library) (localhost link) to confirm the "Amenities" field is present and populating
