### PR TITLE
[WEBSITE-190] Review page load times post Rehype update

### DIFF
--- a/src/components/html.js
+++ b/src/components/html.js
@@ -20,9 +20,7 @@ import { unified } from 'unified';
 */
 const Heading2 = ({ children, ...other }) => {
   return (
-    <Heading level={2} size='M' {...other}>
-      {children}
-    </Heading>
+    <Heading level={2} size='M' {...other}>{children}</Heading>
   );
 };
 
@@ -32,47 +30,37 @@ Heading2.propTypes = {
 
 const Heading3 = ({ children, ...other }) => {
   return (
-    <Heading level={3} size='S' {...other}>
-      {children}
-    </Heading>
+    <Heading level={3} size='S' {...other}>{children}</Heading>
   );
 };
 
 Heading3.propTypes = {
   children: PropTypes.any
 };
+
 const Heading4 = ({ children, ...other }) => {
   return (
-    <Heading
-      level={4}
-      size='3XS'
-      style={{ color: 'var(--color-neutral-300)' }}
-      {...other}
-    >
-      {children}
-    </Heading>
+    <Heading level={4} size='3XS' style={{ color: 'var(--color-neutral-300)' }} {...other}>{children}</Heading>
   );
 };
 
 Heading4.propTypes = {
   children: PropTypes.any
 };
+
 const Heading5 = ({ children, ...other }) => {
   return (
-    <Heading level={5} size='3XS' {...other}>
-      {children}
-    </Heading>
+    <Heading level={5} size='3XS' {...other}>{children}</Heading>
   );
 };
 
 Heading5.propTypes = {
   children: PropTypes.any
 };
+
 const Heading6 = ({ children, ...other }) => {
   return (
-    <Heading level={6} size='3XS' {...other}>
-      {children}
-    </Heading>
+    <Heading level={6} size='3XS' {...other}>{children}</Heading>
   );
 };
 
@@ -82,10 +70,7 @@ Heading6.propTypes = {
 
 const components = {
   a: ({ children, href }) => {
-    if (!children || !href) {
-      return null;
-    }
-    return <Link to={href}>{children}</Link>;
+    return (children && href ? <Link to={href}>{children}</Link> : null);
   },
   article: () => {
     return null;
@@ -103,14 +88,7 @@ const components = {
     return <em {...props} css={{ fontStyle: 'italic' }} />;
   },
   figcaption: (props) => {
-    return (
-      <figcaption
-        {...props}
-        css={{
-          color: 'var(--color-neutral-300)'
-        }}
-      />
-    );
+    return <figcaption {...props} css={{ color: 'var(--color-neutral-300)' }} />;
   },
   figure: (props) => {
     return <figure {...props} css={{ maxWidth: '38rem' }} />;
@@ -127,11 +105,7 @@ const components = {
     return <img {...props} />;
   },
   lede: ({ children, ...other }) => {
-    return (
-      <Text lede {...other}>
-        {children}
-      </Text>
-    );
+    return <Text lede {...other}>{children}</Text>;
   },
   ol: ({ children }) => {
     return <List type='numbered'>{children}</List>;
@@ -141,11 +115,7 @@ const components = {
       return <Callout>{children}</Callout>;
     }
     if (className === 'umich-lib-alert') {
-      return (
-        <Callout intent='warning' alert={true}>
-          {children}
-        </Callout>
-      );
+      return <Callout intent='warning' alert>{children}</Callout>;
     }
     if (className === 'umich-lib-cta') {
       return <CallToAction>{children}</CallToAction>;
@@ -153,9 +123,7 @@ const components = {
     return <Text>{children}</Text>;
   },
   strong: ({ children }) => {
-    return (
-      <strong css={{ fontWeight: '800' }}>{children}</strong>
-    );
+    return <strong css={{ fontWeight: '800' }}>{children}</strong>;
   },
   table: Table,
   text: Text,
@@ -167,39 +135,35 @@ const components = {
   }
 };
 
-const processor = (text) => {
-  return unified()
-    .use(rehypeParse, { fragment: true })
-    .use(rehypeDrupalEntity)
-    .use(rehypeReact, {
-      Fragment: prod.Fragment,
-      components,
-      createElement: (component, props = {}, children = []) => {
-        if (props['data-entity-uuid']) {
-          return <DrupalEntity {...props} />;
-        }
-
-        if (component === 'div') {
-          return <Fragment {...props}>{children}</Fragment>;
-        }
-
-        return createElement(component, props, children);
-      },
-      jsx: prod.jsx,
-      jsxs: prod.jsxs
-    })
-    .process(text);
-};
+const processor = unified()
+  .use(rehypeParse, { fragment: true })
+  .use(rehypeDrupalEntity)
+  .use(rehypeReact, {
+    Fragment: prod.Fragment,
+    components,
+    createElement: (component, props = {}, children = []) => {
+      if (props['data-entity-uuid']) {
+        return <DrupalEntity {...props} />;
+      }
+      if (component === 'div') {
+        return <Fragment {...props}>{children}</Fragment>;
+      }
+      return createElement(component, props, children);
+    },
+    jsx: prod.jsx,
+    jsxs: prod.jsxs
+  });
 
 export default function Html ({ html, ...rest }) {
   const [content, setContent] = useState(<></>);
 
   useEffect(() => {
     (async () => {
-      const file = await processor(html);
+      const file = await processor.process(html);
       setContent(file.result);
     })();
   }, [html]);
+
   return <Prose {...rest}>{content}</Prose>;
 }
 

--- a/src/components/html.js
+++ b/src/components/html.js
@@ -1,7 +1,7 @@
 /* eslint-disable id-length */
 import * as prod from 'react/jsx-runtime';
 import { Heading, List, Text } from '../reusable';
-import React, { createElement, Fragment, useEffect, useState } from 'react';
+import React, { createElement, Fragment } from 'react';
 import Blockquote from '../reusable/blockquote';
 import Callout from '../reusable/callout';
 import CallToAction from '../reusable/call-to-action';
@@ -155,17 +155,9 @@ const processor = unified()
   });
 
 export default function Html ({ html, ...rest }) {
-  const [content, setContent] = useState(<></>);
-
-  useEffect(() => {
-    (async () => {
-      const file = await processor.process(html);
-      setContent(file.result);
-    })();
-  }, [html]);
-
-  return <Prose {...rest}>{content}</Prose>;
-}
+  const file = processor.processSync(html);
+  return <Prose {...rest}>{file.result}</Prose>;
+};
 
 Html.propTypes = {
   html: PropTypes.any


### PR DESCRIPTION
# Overview
After update Rehype / Unified to the latest version, we noticed some delay in rendering content.

It's very noticeable on [the How We Can Help page](https://lib.umich.edu/research-and-scholarship/help-research/how-we-can-help).

When updating the `html.js`, I was following the rehype docs and they are using a `useEffect` hook and followed suit. This pushed the hydration phase back and caused a noticeable jump when content would render in late. I was able to rewrite the function with the help of UMGPT (no shame!) to get rid of the `useEffect` hook and remove the delay.

> This pull request resolves [WEBSITE-190](https://mlit.atlassian.net/browse/WEBSITE-190?focusedCommentId=366334&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-366334).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [x] Edge 
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
- _How to use the feature_.
- `npm run start` the app and check out [the How We Can Help page](http://localhost:8000/research-and-scholarship/help-research/how-we-can-help). Compare it to [the live version](https://lib.umich.edu/research-and-scholarship/help-research/how-we-can-help) to see if it loads in faster. 
