### PR TITLE
Fix for staggered card panels

### DIFF
--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -90,7 +90,7 @@ const PanelList = ({ children, twoColumns, disableLargeScreenStyles = false, ...
     },
     '> li': {
       breakInside: 'avoid',
-      display: 'grid',
+      display: 'inline-block',
       marginBottom: 0,
       marginTop: SPACING.XL
     }

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -85,17 +85,14 @@ const PanelList = ({ children, twoColumns, disableLargeScreenStyles = false, ...
       };
   const panelListColumnStyles = {
     [MEDIA_QUERIES.S]: {
-      columnGap: SPACING['3XL'],
-      columns: '2'
+      columnCount: '2',
+      columnGap: SPACING['3XL']
     },
     '> li': {
       breakInside: 'avoid',
       display: 'grid',
       marginBottom: 0,
       marginTop: SPACING.XL
-    },
-    '> li:first-of-type': {
-      marginTop: 0
     }
   };
 
@@ -306,16 +303,13 @@ const CardPanel = ({ data }) => {
   }
 
   return (
-    <PanelTemplate title={title}>
+    <PanelTemplate title={title} headingCss={{ marginBottom: '0' }}>
       <PanelList twoColumns={noImage}>
         {cards.map((card, item) => {
           return (
             <li
               key={item + card.title}
               css={{
-                ':first-of-type': {
-                  marginTop: 0
-                },
                 marginTop: SPACING.XL,
                 [MEDIA_QUERIES.S]: {
                   margin: '0'
@@ -489,7 +483,7 @@ const TextPanel = ({ data }) => {
 
   if (template === 'grid_text_template_with_linked_title') {
     return (
-      <PanelTemplate title={title}>
+      <PanelTemplate title={title} headingCss={{ marginBottom: '0' }}>
         <PanelList twoColumns>
           {cards.map(({ field_title: fieldTitle, field_body: fieldBody, field_link: fieldLink }, item) => {
             return (

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -85,14 +85,17 @@ const PanelList = ({ children, twoColumns, disableLargeScreenStyles = false, ...
       };
   const panelListColumnStyles = {
     [MEDIA_QUERIES.S]: {
-      columnCount: '2',
-      columnGap: SPACING['3XL']
+      columnGap: SPACING['3XL'],
+      columns: '2'
     },
     '> li': {
       breakInside: 'avoid',
-      display: 'inline-block',
+      display: 'grid',
       marginBottom: 0,
       marginTop: SPACING.XL
+    },
+    '> li:first-of-type': {
+      marginTop: 0
     }
   };
 
@@ -303,13 +306,16 @@ const CardPanel = ({ data }) => {
   }
 
   return (
-    <PanelTemplate title={title} headingCss={{ marginBottom: '0' }}>
+    <PanelTemplate title={title}>
       <PanelList twoColumns={noImage}>
         {cards.map((card, item) => {
           return (
             <li
               key={item + card.title}
               css={{
+                ':first-of-type': {
+                  marginTop: 0
+                },
                 marginTop: SPACING.XL,
                 [MEDIA_QUERIES.S]: {
                   margin: '0'
@@ -483,7 +489,7 @@ const TextPanel = ({ data }) => {
 
   if (template === 'grid_text_template_with_linked_title') {
     return (
-      <PanelTemplate title={title} headingCss={{ marginBottom: '0' }}>
+      <PanelTemplate title={title}>
         <PanelList twoColumns>
           {cards.map(({ field_title: fieldTitle, field_body: fieldBody, field_link: fieldLink }, item) => {
             return (

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -90,12 +90,9 @@ const PanelList = ({ children, twoColumns, disableLargeScreenStyles = false, ...
     },
     '> li': {
       breakInside: 'avoid',
-      display: 'grid',
-      marginBottom: 0,
-      marginTop: SPACING.XL
-    },
-    '> li:first-of-type': {
-      marginTop: 0
+      display: 'inline-block',
+      marginTop: 0,
+      paddingTop: SPACING.XL
     }
   };
 
@@ -306,7 +303,7 @@ const CardPanel = ({ data }) => {
   }
 
   return (
-    <PanelTemplate title={title}>
+    <PanelTemplate title={title} headingCss={{ marginBottom: 0 }}>
       <PanelList twoColumns={noImage}>
         {cards.map((card, item) => {
           return (
@@ -489,14 +486,13 @@ const TextPanel = ({ data }) => {
 
   if (template === 'grid_text_template_with_linked_title') {
     return (
-      <PanelTemplate title={title}>
+      <PanelTemplate title={title} headingCss={{ marginBottom: 0 }}>
         <PanelList twoColumns>
           {cards.map(({ field_title: fieldTitle, field_body: fieldBody, field_link: fieldLink }, item) => {
             return (
               <li
                 key={item + fieldTitle}
                 css={{
-                  marginBottom: SPACING.XL,
                   [MEDIA_QUERIES.S]: {
                     margin: '0'
                   }

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -90,7 +90,7 @@ const PanelList = ({ children, twoColumns, disableLargeScreenStyles = false, ...
     },
     '> li': {
       breakInside: 'avoid',
-      display: 'inline-block',
+      display: 'grid',
       marginBottom: 0,
       marginTop: SPACING.XL
     },


### PR DESCRIPTION
# Overview
Continuation of https://github.com/mlibrary/lib.umich.edu/pull/351

Since that is an outdated and closed PR, I don't think we're able to reopen it.

Using `display: inline-block` appears to have made the items misaligned as seen here:
![image](https://github.com/user-attachments/assets/35084a85-f1ac-4cee-9c4e-0e25d8c7f5dd)

If I change it to `display: grid` that fixes the initial Firefox display issue and the misalignment we're experiencing with `display: inline-block`.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [x] Edge
